### PR TITLE
Hide scrollbar if Dialog content doesn't need scrolling

### DIFF
--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -20,7 +20,7 @@ type DialogProps = {
   isOpen?: boolean
   children?: React.ReactNode
   allowPinchZoom?: boolean
-  style?: any
+  style?: React.CSSProperties
   onDismiss?: () => void
 } & VariantProps &
   SystemProps

--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -53,7 +53,7 @@ const containerStyles = ({ theme }: { theme: Theme }): SerializedStyles =>
     margin: '10vh auto',
     maxHeight: '70vh',
     outline: 'none',
-    overflow: 'scroll',
+    overflow: 'auto',
     padding: '0',
     width: '50vw',
   })(theme)

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@emotion/styled": "^10.0.27",
     "@kodiak-ui/core": "^0.0.0",
-    "@kodiak-ui/dialog": "^0.0.0",
     "@styled-system/should-forward-prop": "^5.1.4",
     "@styled-system/space": "^5.1.2",
     "@theme-ui/css": "^0.3.1",

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@emotion/styled": "^10.0.27",
     "@kodiak-ui/core": "^0.0.0",
+    "@kodiak-ui/dialog": "^0.0.0",
     "@styled-system/should-forward-prop": "^5.1.4",
     "@styled-system/space": "^5.1.2",
     "@theme-ui/css": "^0.3.1",


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->
# Summary

The scrollbar appears sometimes if there's a mouse attached on macos

<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch30259](https://app.clubhouse.io/jilt/story/30259/hide-scrollbar-if-content-doesn-t-need-scrolling)

## :vertical_traffic_light: Acceptance criteria

- [x] Scrollbars only appear if required


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

- [ ] Release: `git push production master`

