### PR TITLE
Color search system for theme

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -19,6 +19,7 @@
     "babel-loader": "^8.0.6",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
     "formik": "^2.1.3",
+    "polished": "^3.4.4",
     "react": "^16.12.0",
     "react-docgen-typescript-loader": "^3.6.0",
     "react-dom": "^16.7.0",

--- a/packages/storybook/src/designsystem/Colors.stories.tsx
+++ b/packages/storybook/src/designsystem/Colors.stories.tsx
@@ -52,19 +52,19 @@ type ColorSwatchesProps = {
 } & React.ComponentProps<typeof Flex>
 
 function ColorSwatches({ colorsArray, colorName }: ColorSwatchesProps) {
-  const borderLeftColor = colorsArray
-    .sort(function darkestColorForSort(color1, color2) {
-      try {
-        const color1Hsl = parseToHsl(color1)
-        const color2Hsl = parseToHsl(color2)
+  const borderLeftColor = [...colorsArray].sort(function darkestColorForSort(
+    color1,
+    color2,
+  ) {
+    try {
+      const color1Hsl = parseToHsl(color1)
+      const color2Hsl = parseToHsl(color2)
 
-        return color1Hsl.lightness - color2Hsl.lightness
-      } catch (error) {
-        return -1
-      }
-    })
-
-    .find(color => !!color)
+      return color1Hsl.lightness - color2Hsl.lightness
+    } catch (error) {
+      return -1
+    }
+  })[0]
 
   return (
     <Flex flexDirection="column" key={colorName} width="100%">

--- a/packages/storybook/src/designsystem/Colors.stories.tsx
+++ b/packages/storybook/src/designsystem/Colors.stories.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 import { Text, Flex, Grid, Box } from '@kodiak-ui/primitives'
-import { useThemeUI } from 'theme-ui'
+import { useThemeUI, Theme } from 'theme-ui'
+import { useForm } from 'react-hook-form'
+import { parseToRgb, parseToHsl } from 'polished'
+import { RgbColor, RgbaColor } from 'polished/lib/types/color'
+
+import { Field, FieldError } from '@kodiak-ui/primitives'
 
 export default {
   title: 'Design System/Colors',
@@ -40,10 +45,19 @@ type ColorSwatchesProps = {
 } & React.ComponentProps<typeof Flex>
 
 function ColorSwatches({ colorsArray, colorName }: ColorSwatchesProps) {
-  // Would be nice to choose this by darkest color, maybe use d3.hsl to compare lightness
-  // since ideally this would support different string color formats
-  // or if convention is lightest to darkest we could take the last color
-  const borderLeftColor = colorsArray.find(color => !!color)
+  const borderLeftColor = colorsArray
+    .sort(function darkestColorForSort(color1, color2) {
+      try {
+        const color1Hsl = parseToHsl(color1)
+        const color2Hsl = parseToHsl(color2)
+
+        return color1Hsl.lightness - color2Hsl.lightness
+      } catch (error) {
+        return -1
+      }
+    })
+
+    .find(color => !!color)
 
   return (
     <Flex flexDirection="column" key={colorName} width="100%">
@@ -73,6 +87,170 @@ function ColorSwatches({ colorsArray, colorName }: ColorSwatchesProps) {
         })}
       </Grid>
     </Flex>
+  )
+}
+
+type VisitorFunction = ({
+  value,
+  key,
+  parentKeys,
+}: {
+  value?: any
+  key?: string
+  parentKeys?: string
+}) => void
+
+// lightweight deep map function
+function deepMapKeys({
+  obj,
+  visitorfunction,
+  key,
+  parentKeys,
+}: {
+  obj: any
+  visitorfunction: VisitorFunction
+  key?: string
+  parentKeys?: string
+}) {
+  if (typeof obj !== 'object') {
+    visitorfunction({ value: obj, key, parentKeys })
+  } else {
+    if (obj) {
+      Object.keys(obj).map(objectKey => {
+        deepMapKeys({
+          obj: obj[objectKey],
+          visitorfunction,
+          key: objectKey,
+          parentKeys:
+            parentKeys !== undefined ? [parentKeys, key].join('.') : key,
+        })
+      })
+    }
+  }
+}
+
+type ColorData = {
+  color: string
+}
+
+function flattenThemeColors({ theme }: { theme: Theme }) {
+  const flattenedThemeColors: Array<{
+    colorKey: string
+    color: string
+    rgbColor: RgbColor | RgbaColor
+  }> = []
+
+  deepMapKeys({
+    obj: theme.colors,
+    visitorfunction: ({ value, key, parentKeys }) => {
+      const colorKey =
+        parentKeys !== undefined ? [parentKeys, key].join('.') : key
+
+      if (!colorKey) {
+        return
+      }
+
+      try {
+        const rgbColor = parseToRgb(value)
+
+        flattenedThemeColors.push({
+          colorKey: colorKey,
+          color: value,
+          rgbColor: rgbColor,
+        })
+      } catch (error) {
+        console.error(`Couldn't parse ${colorKey}:${value}`)
+        console.error(error)
+      }
+    },
+  })
+
+  return flattenedThemeColors
+}
+
+function findNearestThemeColors({
+  theme,
+  color,
+  count,
+}: {
+  theme: Theme
+  color: string
+  count: number
+}) {
+  try {
+    const { red, green, blue } = parseToRgb(color)
+
+    const flattenedThemeColors = flattenThemeColors({ theme })
+    const colorsWithDistance = flattenedThemeColors
+      .map(color => ({
+        ...color,
+        distance: Math.sqrt(
+          2 * Math.pow(color.rgbColor.red - red, 2) +
+            4 * Math.pow(color.rgbColor.green - green, 2) +
+            3 * Math.pow(color.rgbColor.blue - blue, 2),
+        ),
+      }))
+      .sort((a, b) => a.distance - b.distance)
+
+    colorsWithDistance.length = count
+
+    return colorsWithDistance
+  } catch (e) {
+    // couldn't parse the color
+    return null
+  }
+}
+export function NearestThemeColor() {
+  const { register, watch } = useForm<ColorData>()
+  const { theme } = useThemeUI()
+  const color = watch('color')
+
+  if (theme.colors === undefined) {
+    return null
+  }
+
+  const nearestColors = findNearestThemeColors({ theme, color, count: 6 })
+
+  return (
+    <>
+      <form>
+        <Field
+          label="Find the nearest theme colors"
+          name="color"
+          ref={register({ required: false })}
+          aria-describedby="error-first-name-required"
+        ></Field>
+        {color && !nearestColors && (
+          <FieldError id="error-first-name-required">
+            Please enter a valid color (including # for hex)
+          </FieldError>
+        )}
+      </form>
+
+      {nearestColors && (
+        <Flex>
+          <Box>
+            <ColorSwatch
+              key={color}
+              color={color}
+              colorName={'Your color'}
+              pt={4}
+            />
+          </Box>
+
+          <Box>
+            {nearestColors.map((color, index) => (
+              <ColorSwatch
+                key={index}
+                color={color.color}
+                colorName={color.colorKey}
+                pt={4}
+              />
+            ))}
+          </Box>
+        </Flex>
+      )}
+    </>
   )
 }
 

--- a/packages/storybook/src/designsystem/Colors.stories.tsx
+++ b/packages/storybook/src/designsystem/Colors.stories.tsx
@@ -29,6 +29,13 @@ function ColorSwatch({ color, colorName, ...props }: ColorSwatchProps) {
         width={96}
         boxShadow="lg"
         borderRadius="default"
+        sx={{
+          transition: 'all 0.2s ease-in-out',
+          '&:hover': {
+            transform: 'scale(1.2)',
+          },
+        }}
+        onClick={() => navigator.clipboard.writeText(color)}
       />
 
       <Flex ml={4} flexDirection="column" justifyContent="center">
@@ -218,10 +225,10 @@ export function NearestThemeColor() {
           label="Find the nearest theme colors"
           name="color"
           ref={register({ required: false })}
-          aria-describedby="error-first-name-required"
+          aria-describedby="error-color"
         ></Field>
         {color && !nearestColors && (
-          <FieldError id="error-first-name-required">
+          <FieldError id="error-color">
             Please enter a valid color (including # for hex)
           </FieldError>
         )}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13641,6 +13641,13 @@ polished@^3.3.1:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
+polished@^3.4.4:
+  version "3.4.4"
+  resolved "https://registry.yarnpkg.com/polished/-/polished-3.4.4.tgz#ac8cd6e704887398f3b802718f9d389b9ea4307b"
+  integrity sha512-x9PKeExyI9AhWrJP3Q57I1k7GInujjiVBJMPFmycj9hX1yCOo/X9eu9eZwxgOziiXge3WbFQ5XOmkzunOntBSA==
+  dependencies:
+    "@babel/runtime" "^7.6.3"
+
 popper.js@^1.14.4, popper.js@^1.14.7:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.0.tgz#2e1816bcbbaa518ea6c2e15a466f4cb9c6e2fbb3"


### PR DESCRIPTION
# Summary

When trying to reduce the theme down to a fixed set of colors, it's helpful to be able to find the closest colour that is in the theme.  For example, when migrating from a system that does not have a theme to the themed version.

Searching by nearest color can help to find the right color of the theme to use.  It also highlights if there's a specific named color like primary, danger or warning that might match the purpose of the color instead of going to the color directly.

<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch30359](https://app.clubhouse.io/jilt/story/30359/color-search-system-for-theme)

## :vertical_traffic_light: Acceptance criteria

- [x] When visiting the color design system, the color can be searched
- [x] The users chosen color appears beside the matched colors
- [x] An error is shown if the color is not a valid color
- [x] Hovering shows the color larger
- [x] Clicking on the color copies the hex value to clipboard

## Why is this important to our customers or team?

This should also help designers to find a colour that matches what they are looking for from the theme by showing the color chosen beside the theme variants.


<a name="implementation-tasks"></a>

## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

- [ ] Release: `git push production master`

