### PR TITLE
Utilize popper JS for positioning the menu list in Kodiak's menu component

### DIFF
--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "@kodiak-ui/core": "^0.1.14",
-    "@kodiak-ui/hooks": "^0.3.0"
+    "@kodiak-ui/hooks": "^0.3.0",
+    "@popperjs/core": "^2.4.0"
   },
   "gitHead": "e043cf2cbc9ab31a9c84f9ea13c674b5a8157946"
 }

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -164,7 +164,7 @@ interface UseMenuReturnValue {
   getItemProps: (
     name: string,
   ) => { onClick: (() => void) | undefined; onMouseEnter: () => void }
-  Menu: React.ReactNode
+  Menu: any
 }
 
 enum MenuElementTagNames {

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -2,7 +2,6 @@ import * as React from 'react'
 import { createPopper, VirtualElement, Placement } from '@popperjs/core'
 import { usePortal, useKey, useOnClickOutside } from '@kodiak-ui/hooks'
 import { hasKey } from './utils'
-import { OffsetModifier } from '@popperjs/core/lib/modifiers/offset'
 
 /**
  * Create all of the HTML attributes for an element

--- a/packages/storybook/src/Menu/Menu.stories.tsx
+++ b/packages/storybook/src/Menu/Menu.stories.tsx
@@ -13,7 +13,7 @@ function AlignedRight() {
     handleCloseMenu,
     getItemProps,
     Menu,
-  } = useMenu({ align: 'right', width: 91 })
+  } = useMenu({ placement: 'bottom-end' })
 
   return (
     <>
@@ -191,6 +191,7 @@ export function Inital() {
       <Flex sx={{ justifyContent: 'flex-end', p: 5 }}>
         <AlignedRight />
       </Flex>
+      <Box sx={{ height: '1000px', bg: 'purple' }} />
     </>
   )
 }

--- a/packages/storybook/src/Menu/Menu.stories.tsx
+++ b/packages/storybook/src/Menu/Menu.stories.tsx
@@ -191,7 +191,6 @@ export function Inital() {
       <Flex sx={{ justifyContent: 'flex-end', p: 5 }}>
         <AlignedRight />
       </Flex>
-      <Box sx={{ height: '1000px', bg: 'purple' }} />
     </>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,6 +2603,11 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@popperjs/core@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
+  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
+
 "@reach/dialog@^0.8.2":
   version "0.8.6"
   resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.8.6.tgz#964474495e31ac49fb4b901daf254b6ce8e0fcd4"


### PR DESCRIPTION
To ensure proper positioning of React portals, we need to utilize Popper JS to handle the positioning for us. Popper provides a React library for working with portals and will remove a lot of the manual calculations that would be needed.

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch53300](https://app.clubhouse.io/skyverge/story/53300/utilize-popper-js-for-positioning-the-menu-list-in-kodiak-s-menu-component)

This PR will address changes to the following:

- [ ] Components
- [x] Hooks

<a name="qa"></a>

## Acceptance Crtieria

- [x] When a developer is rendering the Menu, the MenuList should always be properly positioned underneath the trigger button.

<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [ ] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
