### PR TITLE
Update focus management for Menu so that the last button is not automatically focused

### DIFF
--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -229,6 +229,14 @@ export function useMenu({
     return itemsRef && itemsRef.current && itemsRef.current[index]
   }
 
+  function focusMenuRef() {
+    menuRef && menuRef.current && menuRef.current.focus()
+  }
+
+  function focusButtonRef() {
+    buttonRef && buttonRef.current && buttonRef.current.focus()
+  }
+
   useKey({
     key: 'Escape',
     target: menuRef.current,
@@ -236,6 +244,7 @@ export function useMenu({
       if (isExpanded) {
         handleClosePortal({})
       }
+      focusButtonRef()
     },
   })
 
@@ -294,19 +303,9 @@ export function useMenu({
     },
   })
 
-  function focusMenuRef() {
-    menuRef && menuRef.current && menuRef.current.focus()
-  }
-
-  function focusButtonRef() {
-    buttonRef && buttonRef.current && buttonRef.current.focus()
-  }
-
   React.useEffect(() => {
     if (isExpanded) {
       focusMenuRef()
-    } else {
-      focusButtonRef()
     }
   }, [isExpanded])
 


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

The menu button should only re-focus after the menu closes due to Esc.

<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch53381](https://app.clubhouse.io/skyverge/story/53381/update-focus-management-for-menu-so-that-the-last-button-is-not-automatically-focused)

## :vertical_traffic_light: Acceptance criteria

- [x] When the menus are added the focus and scroll remains at the initial tabIndex for the page
- [x] After closing a menu by Esc the button is re-focused


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

