### PR TITLE
Support input types and placeholders

### DIFF
--- a/packages/primitives/src/Field/Field.tsx
+++ b/packages/primitives/src/Field/Field.tsx
@@ -4,13 +4,11 @@ import { Label } from '../Label'
 import { Input } from '../Input'
 import { Text } from '../Text'
 
-interface FieldProps {
+interface FieldProps extends React.HTMLAttributes<HTMLInputElement> {
   children?: React.ReactNode
   defaultValue?: string
   label: string
   name: string
-  placeholder?: string
-  type?: string
 }
 
 export const Field = React.forwardRef(
@@ -22,7 +20,13 @@ export const Field = React.forwardRef(
       <Label htmlFor={name} mb={2}>
         {label}
       </Label>
-      <Input ref={ref} id={name} name={name} defaultValue={defaultValue} {...props} />
+      <Input
+        ref={ref}
+        id={name}
+        name={name}
+        defaultValue={defaultValue}
+        {...props}
+      />
       {children}
     </Box>
   ),

--- a/packages/primitives/src/Field/Field.tsx
+++ b/packages/primitives/src/Field/Field.tsx
@@ -22,7 +22,7 @@ export const Field = React.forwardRef(
       <Label htmlFor={name} mb={2}>
         {label}
       </Label>
-      <Input ref={ref} id={name} name={name} type={type} placeholder={placeholder} defaultValue={defaultValue} />
+      <Input ref={ref} id={name} name={name} defaultValue={defaultValue} {...props} />
       {children}
     </Box>
   ),

--- a/packages/primitives/src/Field/Field.tsx
+++ b/packages/primitives/src/Field/Field.tsx
@@ -5,22 +5,24 @@ import { Input } from '../Input'
 import { Text } from '../Text'
 
 interface FieldProps {
+  children?: React.ReactNode
+  defaultValue?: string
   label: string
   name: string
-  defaultValue?: string
-  children?: React.ReactNode
+  placeholder?: string
+  type?: string
 }
 
 export const Field = React.forwardRef(
   (
-    { label, name, defaultValue, children }: FieldProps,
+    { children, defaultValue, label, name, placeholder, type }: FieldProps,
     ref: React.Ref<HTMLInputElement>,
   ) => (
     <Box mb={4}>
       <Label htmlFor={name} mb={2}>
         {label}
       </Label>
-      <Input ref={ref} id={name} name={name} defaultValue={defaultValue} />
+      <Input ref={ref} id={name} name={name} type={type} placeholder={placeholder} defaultValue={defaultValue} />
       {children}
     </Box>
   ),

--- a/packages/primitives/src/Field/Field.tsx
+++ b/packages/primitives/src/Field/Field.tsx
@@ -15,7 +15,7 @@ interface FieldProps {
 
 export const Field = React.forwardRef(
   (
-    { children, defaultValue, label, name, placeholder, type }: FieldProps,
+    { children, defaultValue, label, name, ...props }: FieldProps,
     ref: React.Ref<HTMLInputElement>,
   ) => (
     <Box mb={4}>


### PR DESCRIPTION
The Field Component in the primative package currently does not allow for a type attribute to be passed to the input component field. This results in fields like password not having the proper attributes to be masked by browsers.

**Main Story:** [ch53979](https://app.clubhouse.io/skyverge/story/53979/kodiak-ui-field-component-should-support-type-attribute)

## Acceptance Crtieria

- [x] When a value to the type attribute is passed to field it is applied to the Input component
