### PR TITLE
Remove fixed margin from message

### DIFF
--- a/packages/message/src/Message.tsx
+++ b/packages/message/src/Message.tsx
@@ -53,7 +53,7 @@ export const Message = React.forwardRef<HTMLDivElement, MessageProps>(
         variantKey={variantKey}
         {...props}
       >
-        <Flex alignItems="center" flexGrow={1} mr={4}>
+        <Flex alignItems="center" flexGrow={1}>
           {children}
         </Flex>
         {onDismiss ? (

--- a/packages/message/src/__tests__/Message.spec.tsx
+++ b/packages/message/src/__tests__/Message.spec.tsx
@@ -85,7 +85,6 @@ describe('Message', () => {
         box-sizing: border-box;
         margin: 0;
         min-width: 0;
-        margin-right: 32px;
         -webkit-align-items: center;
         -webkit-box-align: center;
         -ms-flex-align: center;


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

## Summary

On the "add new from address" modals, it looks like there is some extra padding that pushes the "learn more" text onto a second line. Could we remove that padding so that the text is neatly formatted on one line? 

<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch54935](https://app.clubhouse.io/skyverge/story/54935/-from-addresses-content-highlight-text-should-be-on-one-line-in-the-add-new-from-address-modal)

## :vertical_traffic_light: Acceptance criteria

- [x] Within the "Add new from address" modal, the extra padding in the content highlight should be removed so that the text stays on one line. 


<a name="implementation-tasks"></a>

## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

