### PR TITLE
Remove outline on menu and add pointer to item

### DIFF
--- a/packages/menu/src/MenuList.tsx
+++ b/packages/menu/src/MenuList.tsx
@@ -23,6 +23,8 @@ export function base({ theme }: { theme: Theme }): SerializedStyles {
     listStyle: 'none',
     margin: 0,
     mt: 2,
+    outline: 'none',
+    overflow: 'hidden',
     padding: 0,
   })(theme)
 }

--- a/packages/menu/src/MenuListItem.tsx
+++ b/packages/menu/src/MenuListItem.tsx
@@ -16,6 +16,7 @@ export type MenuListItemProps = {
 
 export function base({ theme }: { theme: Theme }): SerializedStyles {
   return css({
+    cursor: 'pointer',
     lineHeight: 1,
     py: 3,
     px: 4,


### PR DESCRIPTION
Table dropdowns via "actions" menus on the From addresses page should not have a focus state by default.

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch54929](https://app.clubhouse.io/skyverge/story/54929/from-addresses-table-dropdowns-should-not-have-focus-state-by-default)

<a name="details"></a>

## Details

Removes the outline around the menu by default, adds the pointer cursor to the list item, and ensures hover respects the border radius.

This PR will address changes to the following:

- [x] Components
- [ ] Hooks

<a name="qa"></a>
<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [x] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
