### PR TITLE
Allow useAccordion to be controlled

### DIFF
--- a/packages/accordion/src/useAccordion.ts
+++ b/packages/accordion/src/useAccordion.ts
@@ -18,18 +18,22 @@ type GetHeaderPropsReturn = {
 
 type UseAccordionProps = {
   defaultExpandedItems?: KeyType[]
+  expandedItems?: KeyType[]
   onChange?: ({ expandedItems }: { expandedItems: KeyType[] }) => void
   allowMultiple?: boolean
 }
 
 export function useAccordion({
   defaultExpandedItems = [],
+  expandedItems: controlledExpandedItems,
   onChange,
   allowMultiple,
 }: UseAccordionProps) {
-  const [expandedItems, setExpandedItems] = React.useState<KeyType[]>(
-    defaultExpandedItems,
+  const [expandedItemsLocal, setExpandedItemsLocal] = React.useState<KeyType[]>(
+    controlledExpandedItems || defaultExpandedItems,
   )
+
+  const expandedItems = controlledExpandedItems || expandedItemsLocal
 
   const elementRefDictionary = React.useRef<{
     accordionHeaders: { [key in KeyType]: AccordionRef }
@@ -43,7 +47,7 @@ export function useAccordion({
     (expanded: KeyType[] | KeyType) => {
       const newExpanded = Array.isArray(expanded) ? expanded : [expanded]
       onChange && onChange({ expandedItems: newExpanded })
-      setExpandedItems(newExpanded)
+      !controlledExpandedItems && setExpandedItemsLocal(newExpanded)
     },
     [onChange],
   )

--- a/packages/storybook/src/Accordion/Accordion.stories.tsx
+++ b/packages/storybook/src/Accordion/Accordion.stories.tsx
@@ -374,3 +374,113 @@ export function AccordionHookMultiple() {
     </Flex>
   )
 }
+
+export function AccordionHookControlled() {
+  const [items, setItems] = React.useState<string[]>(['first'])
+
+  const {
+    expandedItems,
+    setExpandedItems,
+    toggleExpanded,
+    checkIsExpanded,
+  } = useAccordion({
+    expandedItems: items,
+    allowMultiple: true,
+    onChange: ({ expandedItems }) => setItems(expandedItems as string[]),
+  })
+
+  return (
+    <Flex sx={{ flexDirection: 'column', p: 6 }}>
+      <Accordion>
+        <AccordionItem>
+          <AccordionHeader
+            id="firstAccordion"
+            aria-expanded={checkIsExpanded({ key: 'first' })}
+            aria-controls="firstBody"
+            tabIndex={0}
+            onClick={() => {
+              toggleExpanded({ key: 'first' })
+            }}
+            onKeyUp={(event: any) => {
+              if (['Enter', ' '].includes(event.key)) {
+                toggleExpanded({ key: 'first' })
+              }
+            }}
+          >
+            <Text fontWeight="bold" fontSize={3} mb={0}>
+              Accordion header - toggle me
+            </Text>
+            <CaretFillDown
+              sx={{
+                transform: checkIsExpanded({ key: 'first' })
+                  ? 'rotate(180deg)'
+                  : 'rotate(0)',
+              }}
+            />
+          </AccordionHeader>
+          {checkIsExpanded({ key: 'first' }) && (
+            <>
+              <AccordionBody
+                id="firstBody"
+                aria-labelledby="firstAccordion"
+                role="region"
+              >
+                Body
+              </AccordionBody>
+              <AccordionFooter>Footer</AccordionFooter>
+            </>
+          )}
+        </AccordionItem>
+
+        <AccordionItem>
+          <AccordionHeader
+            id="secondAccordion"
+            aria-expanded={checkIsExpanded({ key: 'second' })}
+            aria-controls="secondBody"
+            tabIndex={0}
+            onClick={() => {
+              toggleExpanded({ key: 'second' })
+            }}
+            onKeyUp={(event: any) => {
+              if (['Enter', ' '].includes(event.key)) {
+                toggleExpanded({ key: 'second' })
+              }
+            }}
+          >
+            <Text fontWeight="bold" fontSize={3} mb={0}>
+              Accordion header - toggle me
+            </Text>
+            <CaretFillDown
+              sx={{
+                transform: checkIsExpanded({ key: 'second' })
+                  ? 'rotate(180deg)'
+                  : 'rotate(0)',
+              }}
+            />
+          </AccordionHeader>
+          {checkIsExpanded({ key: 'second' }) && (
+            <>
+              <AccordionBody
+                id="secondBody"
+                aria-labelledby="secondAccordion"
+                role="region"
+              >
+                Body
+              </AccordionBody>
+              <AccordionFooter>Footer</AccordionFooter>
+            </>
+          )}
+        </AccordionItem>
+      </Accordion>
+      <Flex sx={{ pt: 6 }}>
+        <Button variant="secondary" onClick={() => setExpandedItems(['first'])}>
+          Open only the first
+        </Button>
+      </Flex>
+
+      <Flex sx={{ pt: 6 }}>
+        Opened keys: {Array.isArray(expandedItems) && expandedItems.join(', ')}
+      </Flex>
+    </Flex>
+  )
+}


### PR DESCRIPTION
Accepts an `expandedItems` prop to use for controlling the component.

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch54918](https://app.clubhouse.io/skyverge/story/54918/keep-from-address-accordion-as-the-user-set-it)

<a name="details"></a>

## Details


This will allow developers to utilize local or session storage to manage the accordion state.

This PR will address changes to the following:

- [ ] Components
- [x] Hooks

<a name="qa"></a>

<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [x] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
