### PR TITLE
Add useTranslation proxy

### DIFF
--- a/packages/hooks/src/__tests__/useTranslation.spec.ts
+++ b/packages/hooks/src/__tests__/useTranslation.spec.ts
@@ -1,0 +1,15 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import { useTranslation } from '../useTranslation'
+
+describe('translation service', () => {
+  it('should return text string from t', async () => {
+    const { result } = renderHook(() => useTranslation())
+
+    let translatedText = ''
+    act(() => {
+      translatedText = result.current.t('translated text')
+    })
+
+    expect(translatedText).toEqual('translated text')
+  })
+})

--- a/packages/hooks/src/useTranslation.ts
+++ b/packages/hooks/src/useTranslation.ts
@@ -1,0 +1,13 @@
+// Simple proxy function as a placeholder for react-i18next
+// until we need the entire translation library this provides a way to
+// start wrapping our texts
+function t(stringToTranslate: string) {
+  return stringToTranslate
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function useTranslation(scope?: string) {
+  return {
+    t,
+  }
+}


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

Create a translation.service.ts t function that is a placeholder for a future translation service.  This will allow us to start to wrap end user texts now but choose the implementation later and will be modelled after i18next.

- provides a useTranslation hook that accepts an optional `namespace` type
- It returns a t function that is created outside of the scope of useTranslation so that it does not need to be memoized.
- The t function returns the text that is provided t(‘translated text’) => ‘translated text’
This does not include i18next at this time but would be a proxy for the functionality



<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch55360](https://app.clubhouse.io/skyverge/story/55360/create-a-translation-proxy)

## :vertical_traffic_light: Acceptance criteria

- [x] the useTranslation t function does not change between re-renders
- [x] t('test value') returns the same text passed in


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done


### After merge to master

