### PR TITLE
Refactor register to accept options without passing the node

### DIFF
--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@kodiak-ui/core": "^0.1.14",
     "@kodiak-ui/hooks": "^0.5.1",
+    "@kodiak-ui/utils": "^0.0.3",
     "@popperjs/core": "^2.4.0"
   },
   "gitHead": "87aa724b895bd2be4f74dea3a95ed6ca5f6e1c24"

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -131,9 +131,8 @@ interface UseMenuProps {
 }
 
 interface UseMenuReturnValue {
-  register<TElement extends Element>(): (ref: TElement | null) => void
   register<TElement extends Element>(
-    options: RegisterOptions,
+    options?: RegisterOptions,
   ): (ref: TElement | null) => void
   register<TElement extends Element>(
     ref: TElement | null,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -133,11 +133,11 @@ interface UseMenuProps {
 interface UseMenuReturnValue {
   register<TElement extends Element>(): (ref: TElement | null) => void
   register<TElement extends Element>(
-    validationOptions: RegisterOptions,
+    options: RegisterOptions,
   ): (ref: TElement | null) => void
   register<TElement extends Element>(
     ref: TElement | null,
-    validationOptions?: RegisterOptions,
+    options?: RegisterOptions,
   ): void
   register<TElement extends Element>(
     refOrOptions?: RegisterOptions | TElement | null,
@@ -370,11 +370,11 @@ export function useMenu({
 
   function register<TElement extends Element>(): (ref: TElement | null) => void
   function register<TElement extends Element>(
-    validationOptions: RegisterOptions,
+    options: RegisterOptions,
   ): (ref: TElement | null) => void
   function register<TElement extends Element>(
     ref: TElement | null,
-    validationOptions?: RegisterOptions,
+    options?: RegisterOptions,
   ): void
   function register<TElement extends Element>(
     refOrOptions?: RegisterOptions | TElement | null,

--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { createPopper, VirtualElement, Placement } from '@popperjs/core'
-import { setAttributes, isElement } from '@kodiak-ui/utils'
+import { setAttributes } from '@kodiak-ui/utils'
 import { usePortal, useKey, useOnClickOutside, useId } from '@kodiak-ui/hooks'
 
 interface NextIndexProps {
@@ -131,6 +131,14 @@ interface UseMenuProps {
 }
 
 interface UseMenuReturnValue {
+  register<TElement extends Element>(): (ref: TElement | null) => void
+  register<TElement extends Element>(
+    validationOptions: RegisterOptions,
+  ): (ref: TElement | null) => void
+  register<TElement extends Element>(
+    ref: TElement | null,
+    validationOptions?: RegisterOptions,
+  ): void
   register<TElement extends Element>(
     refOrOptions?: RegisterOptions | TElement | null,
     options?: RegisterOptions,
@@ -360,6 +368,14 @@ export function useMenu({
     )
   }
 
+  function register<TElement extends Element>(): (ref: TElement | null) => void
+  function register<TElement extends Element>(
+    validationOptions: RegisterOptions,
+  ): (ref: TElement | null) => void
+  function register<TElement extends Element>(
+    ref: TElement | null,
+    validationOptions?: RegisterOptions,
+  ): void
   function register<TElement extends Element>(
     refOrOptions?: RegisterOptions | TElement | null,
     options?: RegisterOptions,

--- a/packages/menu/src/utils.ts
+++ b/packages/menu/src/utils.ts
@@ -1,6 +1,0 @@
-export function hasKey<O>(
-  obj: O,
-  key: string | number | symbol,
-): key is keyof O {
-  return key in obj
-}

--- a/packages/storybook/src/Menu/Menu.stories.tsx
+++ b/packages/storybook/src/Menu/Menu.stories.tsx
@@ -24,15 +24,13 @@ function AlignedRight() {
         <Menu>
           <MenuList ref={register}>
             <MenuListItem
-              ref={node =>
-                register(node as HTMLLIElement, {
-                  name: 'action1',
-                  handler: () => {
-                    console.log('action1')
-                    handleCloseMenu()
-                  },
-                })
-              }
+              ref={register({
+                name: 'action1',
+                handler: () => {
+                  console.log('action1')
+                  handleCloseMenu()
+                },
+              })}
               {...getItemProps('action1')}
               sx={{
                 ...(activeItem === 'action1'
@@ -43,12 +41,10 @@ function AlignedRight() {
               Action 1
             </MenuListItem>
             <MenuListItem
-              ref={node =>
-                register(node as HTMLLIElement, {
-                  name: 'action2',
-                  handler: () => console.log('action2'),
-                })
-              }
+              ref={register({
+                name: 'action2',
+                handler: () => console.log('action2'),
+              })}
               {...getItemProps('action2')}
               sx={{
                 ...(activeItem === 'action2'
@@ -59,12 +55,10 @@ function AlignedRight() {
               Action 2
             </MenuListItem>
             <MenuListItem
-              ref={node =>
-                register(node as HTMLLIElement, {
-                  name: 'action3',
-                  handler: () => console.log('action3'),
-                })
-              }
+              ref={register({
+                name: 'action3',
+                handler: () => console.log('action3'),
+              })}
               {...getItemProps('action3')}
               sx={{
                 ...(activeItem === 'action3'
@@ -75,12 +69,10 @@ function AlignedRight() {
               Action 3
             </MenuListItem>
             <MenuListItem
-              ref={node =>
-                register(node as HTMLLIElement, {
-                  name: 'action4',
-                  handler: () => console.log('action4'),
-                })
-              }
+              ref={register({
+                name: 'action4',
+                handler: () => console.log('action4'),
+              })}
               {...getItemProps('action4')}
               sx={{
                 ...(activeItem === 'action4'
@@ -118,15 +110,13 @@ export function Inital() {
           <Menu>
             <MenuList ref={register}>
               <MenuListItem
-                ref={node =>
-                  register(node as HTMLLIElement, {
-                    name: 'action1',
-                    handler: () => {
-                      console.log('action1')
-                      handleCloseMenu()
-                    },
-                  })
-                }
+                ref={register({
+                  name: 'action1',
+                  handler: () => {
+                    console.log('action1')
+                    handleCloseMenu()
+                  },
+                })}
                 {...getItemProps('action1')}
                 sx={{
                   ...(activeItem === 'action1'
@@ -137,12 +127,10 @@ export function Inital() {
                 Long Name Action 1
               </MenuListItem>
               <MenuListItem
-                ref={node =>
-                  register(node as HTMLLIElement, {
-                    name: 'action2',
-                    handler: () => console.log('action2'),
-                  })
-                }
+                ref={register({
+                  name: 'action2',
+                  handler: () => console.log('action2'),
+                })}
                 {...getItemProps('action2')}
                 sx={{
                   ...(activeItem === 'action2'
@@ -153,12 +141,10 @@ export function Inital() {
                 Action 2
               </MenuListItem>
               <MenuListItem
-                ref={node =>
-                  register(node as HTMLLIElement, {
-                    name: 'action3',
-                    handler: () => console.log('action3'),
-                  })
-                }
+                ref={register({
+                  name: 'action3',
+                  handler: () => console.log('action3'),
+                })}
                 {...getItemProps('action3')}
                 sx={{
                   ...(activeItem === 'action3'
@@ -169,12 +155,10 @@ export function Inital() {
                 Action 3
               </MenuListItem>
               <MenuListItem
-                ref={node =>
-                  register(node as HTMLLIElement, {
-                    name: 'action4',
-                    handler: () => console.log('action4'),
-                  })
-                }
+                ref={register({
+                  name: 'action4',
+                  handler: () => console.log('action4'),
+                })}
                 {...getItemProps('action4')}
                 sx={{
                   ...(activeItem === 'action4'

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,7 +16,3 @@ export function setAttributes<T extends Element | null>(
       element.setAttribute(key, attributes[key]),
   )
 }
-
-export function isElement(element: any) {
-  return element instanceof Element || element instanceof HTMLDocument
-}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,3 +16,7 @@ export function setAttributes<T extends Element | null>(
       element.setAttribute(key, attributes[key]),
   )
 }
+
+export function isElement(element: any) {
+  return element instanceof Element || element instanceof HTMLDocument
+}


### PR DESCRIPTION
Updates the `register` method for `useMenu` so that it is not required to pass the node as the first argument of the method. If a user passes `register({ handler: () => null })` to `ref` it will automatically assign the node to the ref without having to pass it as the first argument to `register`.

<a name="details"></a>

## Details

This is not a breaking change, but will provide a better API in the for registering elements.

This PR will address changes to the following:

- [ ] Components
- [x] Hooks

<a name="qa"></a>

## Acceptance Crtieria

Menu component should still work as expected and accept both ways of assigning refs and all types pass

<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [ ] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
