### PR TITLE
Refactor the Radio input in Kodiak UI to utilize sx and remove styled system

### DIFF
--- a/packages/primitives/src/Radio/Radio.tsx
+++ b/packages/primitives/src/Radio/Radio.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
-import { Box, SystemProps, VariantProps } from '../Box'
+import { Box, VariantProps } from '../Box'
 import { SvgIcon } from '../Svg'
 import { Input } from '../Input'
 
 type InputProps = {
   sx?: object
 } & VariantProps &
-  SystemProps &
   React.InputHTMLAttributes<HTMLInputElement>
 
 type RadioIcon = Pick<InputProps, 'sx' | 'variant' | 'variantKey'>
@@ -72,19 +71,21 @@ function RadioIcon({ sx, variant, variantKey }: InputProps) {
 
 export const Radio = React.forwardRef(
   (
-    { variant = 'radio', variantKey = 'forms', ...props }: InputProps,
+    { variant = 'radio', variantKey = 'forms', sx, ...props }: InputProps,
     ref: React.Ref<HTMLInputElement>,
   ) => (
     <Box>
       <Input
         ref={ref}
         type="radio"
-        position="absolute"
-        opacity={0}
-        zIndex={-1}
-        width={1}
-        height={1}
-        overflow="hidden"
+        sx={{
+          height: 1,
+          opacity: 0,
+          overflow: 'hidden',
+          position: 'absolute',
+          width: 1,
+          zIndex: -1,
+        }}
         {...props}
       />
       <RadioIcon
@@ -95,6 +96,7 @@ export const Radio = React.forwardRef(
             outlineOffset: '1px',
             outlineColor: 'primary',
           },
+          ...sx,
         }}
         variant={variant}
         variantKey={variantKey}

--- a/packages/primitives/src/Radio/Radio.tsx
+++ b/packages/primitives/src/Radio/Radio.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
-import { Box, VariantProps } from '../Box'
+import { VariantProps, SxStyleProp } from '@kodiak-ui/core'
+import { Box } from '../Box'
 import { SvgIcon } from '../Svg'
 import { Input } from '../Input'
 
 type InputProps = {
-  sx?: object
+  sx?: SxStyleProp
 } & VariantProps &
   React.InputHTMLAttributes<HTMLInputElement>
 

--- a/packages/primitives/src/Radio/__tests__/Radio.spec.tsx
+++ b/packages/primitives/src/Radio/__tests__/Radio.spec.tsx
@@ -55,11 +55,11 @@ describe('Radio', () => {
         border-radius: default;
         color: inherit;
         background-color: transparent;
-        opacity: 0;
-        width: 100%;
         height: 1px;
+        opacity: 0;
         overflow: hidden;
         position: absolute;
+        width: 1px;
         z-index: -1;
       }
 
@@ -200,11 +200,11 @@ describe('Radio', () => {
         border-radius: default;
         color: inherit;
         background-color: transparent;
-        opacity: 0;
-        width: 100%;
         height: 1px;
+        opacity: 0;
         overflow: hidden;
         position: absolute;
+        width: 1px;
         z-index: -1;
       }
 

--- a/packages/storybook/src/primitives/Radio/Radio.stories.tsx
+++ b/packages/storybook/src/primitives/Radio/Radio.stories.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
-import { Label, Radio } from '@kodiak-ui/primitives'
+import { Box, Flex, Text, Label, Radio } from '@kodiak-ui/primitives'
 
 import { withA11y } from '@storybook/addon-a11y'
 
 export default { title: 'Forms/Radio', decorators: [withA11y] }
 
-export function initial() {
+export function Initial() {
   return (
     <>
       <Label display="flex" alignItems="center">
@@ -20,6 +20,42 @@ export function initial() {
       <Label display="flex" alignItems="center">
         <Radio name="dark-mode" value="false" />
         Light Mode
+      </Label>
+    </>
+  )
+}
+
+export function Multiline() {
+  return (
+    <>
+      <Label>
+        <Flex sx={{ alignItems: 'center' }}>
+          <Radio
+            variant="radio"
+            name="dark-mode"
+            value="true"
+            defaultChecked={true}
+          />
+          Dark Mode
+        </Flex>
+        <Box>
+          <Text sx={{ fontWeight: 'normal' }}>
+            This is some more text that we want to render in the label so that
+            it is clickable
+          </Text>
+        </Box>
+      </Label>
+      <Label>
+        <Flex sx={{ alignItems: 'center' }}>
+          <Radio name="dark-mode" value="false" />
+          Light Mode
+        </Flex>
+        <Box>
+          <Text sx={{ fontWeight: 'normal' }}>
+            This is some more text that we want to render in the label so that
+            it is clickable
+          </Text>
+        </Box>
       </Label>
     </>
   )


### PR DESCRIPTION
There are some styling issues with the Radio component in Kodiak due to sx being passed to the container and the input element at the same time that are causing width issues for the input. We need to refactor this component to remove the system props and pass the sx prop only to the SVG children, not to the actual inputelement.

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch56711](https://app.clubhouse.io/skyverge/story/56711/refactor-the-radio-input-in-kodiak-ui-to-utilize-sx-and-remove-styled-system)

<a name="details"></a>

## Details

<!-- Additional details (especially implementation considerations) to expand on the summary, if needed. -->

This PR will address changes to the following:

- [x] Components
- [ ] Hooks

<a name="qa"></a>

## Acceptance Crtieria

- [x] Radio input should not be able to be styled via system props
- [x] sx prop should only be passed to the Svg components, not to the input

<a name="API Changes"></a>

## API Changes

- [x] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [ ] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [ ] **[Documentation]** Documentation has been written or updated
