### PR TITLE
Add optional onOverlayDismiss

### DIFF
--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -15,7 +15,10 @@ type DialogProps = {
   children?: React.ReactNode
   allowPinchZoom?: boolean
   style?: React.CSSProperties
-  onDismiss?: () => void
+  onDismiss?: React.ComponentProps<typeof DialogHeader>['onDismiss']
+  onOverlayDismiss?: React.ComponentProps<
+    typeof ReachDialogOverlay
+  >['onDismiss']
 } & VariantProps
 
 const globalStyles = ({ theme }: { theme: Theme }): SerializedStyles =>
@@ -78,6 +81,7 @@ export const DialogContainer = styled(ReachDialogContent)<DialogProps>(
 export function Dialog({
   isOpen,
   onDismiss,
+  onOverlayDismiss,
   title,
   children,
   variant,
@@ -85,7 +89,11 @@ export function Dialog({
 }: DialogProps & { title?: string | React.ReactNode }) {
   return (
     <>
-      <DialogOverlay isOpen={isOpen} onDismiss={onDismiss} {...props}>
+      <DialogOverlay
+        isOpen={isOpen}
+        onDismiss={onOverlayDismiss || onDismiss}
+        {...props}
+      >
         <DialogContainer {...props} variant={variant}>
           <DialogHeader onDismiss={onDismiss}>{title}</DialogHeader>
           {children}

--- a/packages/dialog/src/__tests__/Dialog.spec.tsx
+++ b/packages/dialog/src/__tests__/Dialog.spec.tsx
@@ -3,7 +3,11 @@ import { render, fireEvent } from '@testing-library/react'
 import { Dialog, DialogContent, DialogFooter } from '../'
 import { Text, Button } from '@kodiak-ui/primitives'
 
-function DialogExample() {
+function DialogExample({
+  onOverlayDismiss,
+}: {
+  onOverlayDismiss?: () => void
+}) {
   const [isOpen, setIsOpen] = React.useState(false)
 
   return (
@@ -14,6 +18,7 @@ function DialogExample() {
       <Button onClick={() => setIsOpen(true)}>Show default example</Button>
       <Dialog
         isOpen={isOpen}
+        onOverlayDismiss={onOverlayDismiss}
         title={
           <div>
             <Text as="h3" mb={2}>
@@ -98,5 +103,27 @@ describe('Dialog', () => {
 
     expect(queryByText('Testing')).toBeNull()
     expect(queryByTestId('closeButton')).toBeNull()
+  })
+
+  it('should block closing the modal modal', () => {
+    const handleDismiss = jest.fn()
+    const { getByText, queryByTestId } = render(
+      <DialogExample onOverlayDismiss={handleDismiss} />,
+    )
+
+    const trigger = getByText('Show default example')
+
+    expect(trigger).toBeTruthy()
+    expect(queryByTestId('closeButton')).toBeNull()
+
+    fireEvent.click(trigger)
+
+    expect(getByText('Testing')).toBeTruthy()
+
+    fireEvent.keyDown(getByText('Testing'), { key: 'Escape', code: 27 })
+
+    expect(handleDismiss).toBeCalledTimes(1)
+
+    expect(getByText('Show default example')).toBeTruthy()
   })
 })

--- a/packages/storybook/src/Dialog/Dialog.stories.tsx
+++ b/packages/storybook/src/Dialog/Dialog.stories.tsx
@@ -206,6 +206,57 @@ export function FullWidth() {
   )
 }
 
+export function BlockDismiss() {
+  const [isOpen, setIsOpen] = React.useState(false)
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>Show dismiss example</Button>
+      <Dialog
+        isOpen={isOpen}
+        title={
+          <div>
+            <Text as="h3" mb={2}>
+              Testing
+            </Text>
+            <Text mb={0}>Testing some text</Text>
+          </div>
+        }
+        onOverlayDismiss={() => alert('blocked from overlay and ESC closing')}
+        onDismiss={() => alert('blocked from closing from close icon')}
+        aria-label="Warning about next steps"
+      >
+        <DialogContent>
+          <Text as="p">
+            Contrary to popular belief, Lorem Ipsum is not simply random text.
+            It has roots in a piece of classical Latin literature from 45 BC,
+            making it over 2000 years old. Richard McClintock, a Latin professor
+            at Hampden-Sydney College in Virginia, looked up one of the more
+            obscure Latin words, consectetur, from a Lorem Ipsum passage, and
+            going through the cites of the word in classical literature,
+            discovered the undoubtable source. Lorem Ipsum comes from sections
+            1.10.32 and 1.10.33 of &quot;de Finibus Bonorum et Malorum&quot;
+            (The Extremes of Good and Evil) by Cicero, written in 45 BC. This
+            book is a treatise on the theory of ethics, very popular during the
+            Renaissance. The first line of Lorem Ipsum, &quot;Lorem ipsum dolor
+            sit amet..&quot;, comes from a line in section 1.10.32. The standard
+            chunk of Lorem Ipsum used since the 1500s is reproduced below for
+            those interested. Sections 1.10.32 and 1.10.33 from &quot;de Finibus
+            Bonorum et Malorum&quot; by Cicero are also reproduced in their
+            exact original form, accompanied by English versions from the 1914
+            translation by H. Rackham.
+          </Text>
+        </DialogContent>
+        <DialogFooter>
+          {/* eslint-disable-next-line @typescript-eslint/no-empty-function */}
+          <Button ml="auto" onClick={() => setIsOpen(false)}>
+            Close
+          </Button>
+        </DialogFooter>
+      </Dialog>
+    </>
+  )
+}
+
 export function Animated() {
   const AnimatedDialogOverlay = animated(DialogOverlay)
   const AnimatedDialogContent = animated(DialogContainer)


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

Allow passing down an onOverlayDismiss so that it can be disabled for dialogs that we don't want to be easily dismissed.  For example forms, or forms with dropdown elements that extend outside of the space.


<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch57617](https://app.clubhouse.io/skyverge/story/57617/allow-passing-on-overlay-click-handler-that-defaults-to-on-dismiss-for)

## :vertical_traffic_light: Acceptance criteria

- [x] When a custom event handler can be passed it is called on esc or click
- [x] When no event handler is called, it defaults to onDismiss (backwards compatible behaviour) 

## Details

Discussion https://skyverge.slack.com/archives/C0138FU1XEX/p1593156225322300?thread_ts=1593155872.321500&cid=C0138FU1XEX


<a name="implementation-tasks"></a>

## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

