### PR TITLE
Pass name and allow pass through props

### DIFF
--- a/packages/primitives/src/Checkbox/__tests__/Checkbox.spec.tsx
+++ b/packages/primitives/src/Checkbox/__tests__/Checkbox.spec.tsx
@@ -91,6 +91,7 @@ describe('Checkbox', () => {
           <input
             checked={true}
             className="emotion-0"
+            name="dark-mode"
             onChange={[Function]}
             type="checkbox"
           />
@@ -208,6 +209,7 @@ describe('Checkbox', () => {
           <input
             checked={false}
             className="emotion-0"
+            name="dark-mode"
             onChange={[Function]}
             type="checkbox"
           />

--- a/packages/primitives/src/Checkbox/useCheckbox.ts
+++ b/packages/primitives/src/Checkbox/useCheckbox.ts
@@ -13,6 +13,7 @@ export function useCheckbox({
   readOnly,
   disabled,
   onChange,
+  name,
 }: UseCheckboxProps) {
   const [isChecked, setIsChecked] = useControlled({
     controlled: checkedProp,
@@ -49,7 +50,7 @@ export function useCheckbox({
   )
 
   const getInputProps = React.useCallback(
-    function getInputProps() {
+    function getInputProps(...props) {
       return {
         id: id,
         type: 'checkbox',
@@ -58,9 +59,11 @@ export function useCheckbox({
         disabled,
         'aria-disabled': disabled,
         onChange: handleOnChange,
+        name,
+        ...props,
       }
     },
-    [id, readOnly, disabled, isChecked, handleOnChange],
+    [id, readOnly, disabled, isChecked, handleOnChange, name],
   )
 
   const getIconProps = React.useCallback(


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

Name property should be passed through to the checkbox for form libraries like `react-hook-form`

<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch60512](https://app.clubhouse.io/skyverge/story/60512/fix-checkbox-to-pass-through-name-property)

## :vertical_traffic_light: Acceptance criteria

- [x] When a name is provided it is passed down to the input


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done


### After merge to master

