### PR TITLE
Remove register function and add a unique ID

### DIFF
--- a/packages/storybook/src/Table/Table.stories.tsx
+++ b/packages/storybook/src/Table/Table.stories.tsx
@@ -145,12 +145,13 @@ export function Initial() {
     [],
   )
 
-  const { register, headers, rows, getTableProps } = useTable<Row>({
+  const labelRef = React.useRef<HTMLHeadingElement>(null)
+
+  const { headers, rows, getTableProps } = useTable<Row>({
     columns,
     data,
+    describedby: labelRef,
   })
-
-  const labelRef = React.useRef<HTMLHeadingElement>(null)
 
   return (
     <>
@@ -158,10 +159,7 @@ export function Initial() {
         Table example
       </h1>
 
-      <Table
-        ref={node => register(node, { describedby: labelRef })}
-        {...getTableProps()}
-      >
+      <Table {...getTableProps()}>
         <TableHead>
           <TableRow>
             {headers.map(({ key, column, ...header }) => (

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -5,7 +5,6 @@
   "main": "dist/table.cjs.js",
   "module": "dist/table.esm.js",
   "source": "src/index.ts",
-
   "files": [
     "dist"
   ],
@@ -14,17 +13,15 @@
   "publishConfig": {
     "access": "public"
   },
-  "scripts": {
-
-  },
-  "devDependencies": {
-  },
+  "scripts": {},
+  "devDependencies": {},
   "peerDependencies": {
     "react": "^16.13.0",
     "react-dom": "^16.13.0"
   },
   "dependencies": {
     "@kodiak-ui/core": "^0.1.14",
+    "@kodiak-ui/hooks": "^0.9.1",
     "@kodiak-ui/primitives": "^0.16.5"
   },
   "gitHead": "35b7b93d2cd6cfef459ac533babfd0cd9e6d936b"

--- a/packages/table/src/__tests__/useTable.spec.tsx
+++ b/packages/table/src/__tests__/useTable.spec.tsx
@@ -27,9 +27,10 @@ const data = [
 ]
 
 function Table() {
-  const { headers, rows } = useTable({
+  const { headers, rows, getTableProps } = useTable({
     columns,
     data,
+    describedby: 'LabelId',
   })
 
   return (
@@ -37,7 +38,7 @@ function Table() {
       <h1 id="LabelId" data-testid="describedByLabel">
         Table example
       </h1>
-      <table data-testid="table">
+      <table data-testid="table" {...getTableProps()}>
         <thead>
           <tr>
             {headers.map(({ key, ...header }) => (
@@ -64,9 +65,10 @@ function Table() {
 
 function TableWithLabelRef() {
   const labelRef = React.useRef<HTMLHeadingElement>(null)
-  const { headers, rows } = useTable({
+  const { headers, rows, getTableProps } = useTable({
     columns,
     data,
+    describedby: labelRef,
   })
 
   return (
@@ -74,7 +76,7 @@ function TableWithLabelRef() {
       <h1 ref={labelRef} id="LabelId">
         Table example
       </h1>
-      <table data-testid="table">
+      <table data-testid="table" {...getTableProps()}>
         <thead>
           <tr>
             {headers.map(({ key, ...header }) => (

--- a/packages/table/src/__tests__/useTable.spec.tsx
+++ b/packages/table/src/__tests__/useTable.spec.tsx
@@ -27,7 +27,7 @@ const data = [
 ]
 
 function Table() {
-  const { register, headers, rows } = useTable({
+  const { headers, rows } = useTable({
     columns,
     data,
   })
@@ -37,10 +37,7 @@ function Table() {
       <h1 id="LabelId" data-testid="describedByLabel">
         Table example
       </h1>
-      <table
-        ref={node => register(node, { describedby: 'LabelId' })}
-        data-testid="table"
-      >
+      <table data-testid="table">
         <thead>
           <tr>
             {headers.map(({ key, ...header }) => (
@@ -67,7 +64,7 @@ function Table() {
 
 function TableWithLabelRef() {
   const labelRef = React.useRef<HTMLHeadingElement>(null)
-  const { register, headers, rows } = useTable({
+  const { headers, rows } = useTable({
     columns,
     data,
   })
@@ -77,10 +74,7 @@ function TableWithLabelRef() {
       <h1 ref={labelRef} id="LabelId">
         Table example
       </h1>
-      <table
-        ref={node => register(node, { describedby: labelRef })}
-        data-testid="table"
-      >
+      <table data-testid="table">
         <thead>
           <tr>
             {headers.map(({ key, ...header }) => (
@@ -196,8 +190,6 @@ describe('useTable', () => {
         "rowIndex": 0,
       }
     `)
-
-    expect(result.current.register).toBeDefined()
   })
 
   it('should add the appropriate HTML attributes to the table element with string ID passed to describedby', () => {

--- a/packages/table/src/useTable.ts
+++ b/packages/table/src/useTable.ts
@@ -89,11 +89,14 @@ export function useTable<Data>({
         }
       }
 
-      if (describedby.current && describedby.current.id) {
+      if (describedby?.current?.id) {
         return {
           'aria-describedby': describedby.current.id,
         }
-      } else if (process.env.NODE_ENV !== 'production') {
+      } else if (
+        process.env.NODE_ENV !== 'production' &&
+        !describedby?.current?.id
+      ) {
         console.warn(
           `When passing a ref, the ref element must have an ID: @${describedby.current}`,
         )

--- a/packages/table/src/useTable.ts
+++ b/packages/table/src/useTable.ts
@@ -56,11 +56,11 @@ function hasWidthProvided(columns?: ColumnProps[]) {
 export function useTable<Data>({
   columns,
   data,
-  id,
+  id: userId,
   describedby,
 }: UseTableProps<Data>): UseTableReturnValue<Data> {
   const [hasFixedTableWidth, setHasFixedTableWidth] = React.useState(false)
-  const id = useId()
+  const id = useId(userId)
 
   React.useEffect(
     function checkHasWidthProvided() {
@@ -151,7 +151,7 @@ export function useTable<Data>({
   const getTableProps = React.useCallback((): GetTableProps => {
     return {
       ...getDescribedByAriaText(),
-      id: id || `kodiak-ui-table-${id}`,
+      id: `kodiak-ui-table-${id}`,
       sx: {
         tableLayout: hasFixedTableWidth ? 'fixed' : 'auto',
         width: hasFixedTableWidth ? 'auto' : '100%',

--- a/packages/table/src/useTable.ts
+++ b/packages/table/src/useTable.ts
@@ -28,9 +28,10 @@ export interface HeaderProps<Data> extends CellProps<Data> {
   scope: string
 }
 
-export interface UseTableOptions<Data> {
+export interface UseTableProps<Data> {
   columns: ColumnProps[]
   data: Data[]
+  id?: string
   describedby?: React.MutableRefObject<any> | string
 }
 
@@ -55,8 +56,9 @@ function hasWidthProvided(columns?: ColumnProps[]) {
 export function useTable<Data>({
   columns,
   data,
+  id,
   describedby,
-}: UseTableOptions<Data>): UseTableReturnValue<Data> {
+}: UseTableProps<Data>): UseTableReturnValue<Data> {
   const [hasFixedTableWidth, setHasFixedTableWidth] = React.useState(false)
   const id = useId()
 
@@ -97,7 +99,7 @@ export function useTable<Data>({
         )
       }
     },
-    [],
+    [describedby],
   )
 
   /**
@@ -149,7 +151,7 @@ export function useTable<Data>({
   const getTableProps = React.useCallback((): GetTableProps => {
     return {
       ...getDescribedByAriaText(),
-      id: `kodiak-ui-table-${id}`,
+      id: id || `kodiak-ui-table-${id}`,
       sx: {
         tableLayout: hasFixedTableWidth ? 'fixed' : 'auto',
         width: hasFixedTableWidth ? 'auto' : '100%',


### PR DESCRIPTION
The `register` method was not really beneficial since it was only adding the `id` and the `aria-describedby` HTML attributes to the table. This PR moves these attributes to the `getTableProps` method and adds a `describedby` prop to the `useTable` hook. 

The ID of the table will be auto-generated if one is not provided.

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch61734](https://app.clubhouse.io/skyverge/story/61734/move-register-method-inside-of-the-usetable-hook)
[ch61735](https://app.clubhouse.io/skyverge/story/61735/update-usetable-to-generate-a-unique-id-for-each-table-that-is-rendered-with-the-hook)

<a name="details"></a>

## Details

<!-- Additional details (especially implementation considerations) to expand on the summary, if needed. -->

This PR will address changes to the following:

- [ ] Components
- [x] Hooks

<a name="qa"></a>

## Acceptance Crtieria

- [x] Developer should be able to use the `useTable` hook without the `register` method
- [x] Developer should be able to pass `describedby` as an option to add the `aria-describedby` HTML attribute

<a name="API Changes"></a>

## API Changes

- [ ] **[Breaking]** This PR introduces breaking changes
- [ ] **[Documentation]** Documentation has been written about the API change

<!-- Details about any API changes that have occurred to a component or hook -->

<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [x] **[QA]** User-testing/quality assurance done
- [x] **[Test]** All components and hooks should have a corresponding unit test
- [x] **[Storybook]** All components and hooks should have a corresponding Storybook story
- [x] **[Documentation]** Documentation has been written or updated
- [ ] **[Version]** Version number has been updated
