### PR TITLE
Add default aria label to kodiak dialog

### DIFF
--- a/packages/dialog/src/Dialog.tsx
+++ b/packages/dialog/src/Dialog.tsx
@@ -94,7 +94,11 @@ export function Dialog({
         onDismiss={onOverlayDismiss || onDismiss}
         {...props}
       >
-        <DialogContainer {...props} variant={variant}>
+        <DialogContainer
+          {...props}
+          variant={variant}
+          aria-label={props?.['aria-label'] || title}
+        >
           <DialogHeader onDismiss={onDismiss}>{title}</DialogHeader>
           {children}
         </DialogContainer>

--- a/packages/storybook/src/Dialog/Dialog.stories.tsx
+++ b/packages/storybook/src/Dialog/Dialog.stories.tsx
@@ -74,7 +74,6 @@ export function Expanding() {
         isOpen={isOpen}
         title="Dialog that grows with the content"
         onDismiss={() => setIsOpen(false)}
-        aria-label="Warning about next steps"
       >
         <DialogContent>
           <Text as="p">


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

The title can be used to default the `aria-label` for a dialog so that it doesn't need to be specified in addition to the title.  



<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch62520](https://app.clubhouse.io/skyverge/story/62520/add-default-aria-label-to-kodiak-dialog)

## :vertical_traffic_light: Acceptance criteria

- [x] when dialogs are opened they have the aria-label assigned if there's a `title`


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

