### PR TITLE
Add Button, AnchorButton, Link event logging to kodiak

### DIFF
--- a/packages/combobox/src/ComboboxButton.tsx
+++ b/packages/combobox/src/ComboboxButton.tsx
@@ -32,7 +32,12 @@ export const ComboboxButton = React.forwardRef(function ComboboxButton(
   )
 
   return (
-    <Button __base={baseStyles} ref={ref} variantKey={variantKey} {...props}>
+    <Button
+      __base={baseStyles}
+      ref={ref as any}
+      variantKey={variantKey}
+      {...props}
+    >
       {children}
     </Button>
   )

--- a/packages/hooks/src/__tests__/useEventLogger.spec.ts
+++ b/packages/hooks/src/__tests__/useEventLogger.spec.ts
@@ -1,5 +1,9 @@
 import { renderHook } from '@testing-library/react-hooks'
-import { useEventLogger, useEventLoggerReducers } from '../useEventLogger'
+import {
+  useEventLogger,
+  useEventLoggerReducers,
+  useWrappedEventHandler,
+} from '../useEventLogger'
 import { useEventLogRoute } from '../useEventLogRoute'
 
 describe('useEventLogger', () => {
@@ -46,5 +50,28 @@ describe('useEventLogger', () => {
 
     expect(log.length).toBe(4)
     expect(log[3].payload.location).toBe('/my_account')
+  })
+
+  it('should add an event wrapper', () => {
+    const addToPayload = jest.fn(event => ({
+      test: true,
+      href: event.target.href,
+    }))
+    const handler = jest.fn()
+    const hook = renderHook(() =>
+      useWrappedEventHandler({
+        name: 'TEST_WRAPPER',
+        addToPayload,
+        handler,
+      }),
+    )
+
+    const event = { target: { href: 'https://jilt.com' } }
+    hook.result?.current(event)
+    expect(addToPayload).toBeCalledTimes(1)
+    expect(addToPayload).toBeCalledWith(event)
+    expect(addToPayload).toReturnWith({ test: true, href: event.target.href })
+    expect(handler).toBeCalledTimes(1)
+    expect(handler).toBeCalledWith(event)
   })
 })

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -62,7 +62,7 @@ export function useEventLoggerReducers(
 }
 
 type UseWrappedEventHandlerProps = {
-  isActive?: boolean
+  isLoggingEventsActive?: boolean
   name: string
   handler?: (any) => void
   addToPayload?: (event) => void
@@ -72,7 +72,7 @@ export function useWrappedEventHandler({
   name,
   handler,
   addToPayload,
-  isActive = true,
+  isLoggingEventsActive: isActive = true,
 }: UseWrappedEventHandlerProps) {
   // use ref's in case they are not memoized so the user doesn't need
   // to remember to memoize
@@ -99,7 +99,7 @@ export function useWrappedEventHandler({
       }
       handlerRef?.current?.handler?.(sourceEvent)
     },
-    [isActive, name], // eslint prefers a function so that it can check the dependencies statically so we useMemo instead of useCallback
+    [isActive, name],
   )
 
   return wrappedEvent

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -60,3 +60,20 @@ export function useEventLoggerReducers(
 
   return [eventReducers, setEventReducers]
 }
+
+export function wrapHandlerWithLog({ name, handler }) {
+  return event => {
+    const target = event?.target as HTMLElement
+    const logEvent = useEventLoggerStore.getState().logEvent
+
+    logEvent({
+      name,
+      payload: {
+        event,
+        sourceLabel: target?.getAttribute('aria-label') || target.textContent,
+      },
+    })
+
+    handler?.(event)
+  }
+}

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -65,6 +65,7 @@ type WrapHandlerWithLogProps = {
   name?: string
   handler?: (any) => void
   addToPayload?: (event) => void
+  eventLog?: boolean
 }
 
 export function wrapHandlerWithLog({

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -90,7 +90,7 @@ export function useWrappedEventHandler({
           payload: {
             sourceEvent,
             sourceLabel:
-              target?.getAttribute('aria-label') || target.textContent,
+              target?.getAttribute?.('aria-label') || target.textContent,
             ...(handlerRef?.current?.addToPayload
               ? handlerRef?.current?.addToPayload?.(sourceEvent)
               : {}),

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -61,7 +61,17 @@ export function useEventLoggerReducers(
   return [eventReducers, setEventReducers]
 }
 
-export function wrapHandlerWithLog({ name, handler }) {
+type WrapHandlerWithLogProps = {
+  name?: string
+  handler?: (any) => void
+  addToPayload?: (event) => void
+}
+
+export function wrapHandlerWithLog({
+  name,
+  handler,
+  addToPayload,
+}: WrapHandlerWithLogProps) {
   return event => {
     const target = event?.target as HTMLElement
     const logEvent = useEventLoggerStore.getState().logEvent
@@ -71,6 +81,7 @@ export function wrapHandlerWithLog({ name, handler }) {
       payload: {
         event,
         sourceLabel: target?.getAttribute('aria-label') || target.textContent,
+        ...(addToPayload ? addToPayload(event) : {}),
       },
     })
 

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -72,19 +72,19 @@ export function wrapHandlerWithLog({
   handler,
   addToPayload,
 }: WrapHandlerWithLogProps) {
-  return event => {
-    const target = event?.target as HTMLElement
+  return sourceEvent => {
+    const target = sourceEvent?.target as HTMLElement
     const logEvent = useEventLoggerStore.getState().logEvent
 
     logEvent({
       name,
       payload: {
-        event,
+        sourceEvent,
         sourceLabel: target?.getAttribute('aria-label') || target.textContent,
-        ...(addToPayload ? addToPayload(event) : {}),
+        ...(addToPayload ? addToPayload(sourceEvent) : {}),
       },
     })
 
-    handler?.(event)
+    handler?.(sourceEvent)
   }
 }

--- a/packages/pagination/src/PaginationButton.tsx
+++ b/packages/pagination/src/PaginationButton.tsx
@@ -12,6 +12,7 @@ export type PaginationButtonProps = {
 
 export function PaginationButton({
   children,
+  ref,
   ...props
 }: PaginationButtonProps) {
   return (
@@ -39,6 +40,7 @@ export function PaginationButton({
           borderRight: 'none',
         },
       }}
+      ref={ref as any}
       {...props}
     >
       {children}

--- a/packages/pagination/src/__tests__/PaginationButton.spec.tsx
+++ b/packages/pagination/src/__tests__/PaginationButton.spec.tsx
@@ -66,6 +66,7 @@ describe('PaginationButton', () => {
 
       <button
         className="emotion-0"
+        onClick={[Function]}
       >
         Rendering Pagination Button
       </button>

--- a/packages/primitives/src/Button/AnchorButton.tsx
+++ b/packages/primitives/src/Button/AnchorButton.tsx
@@ -40,20 +40,23 @@ export const StyledAnchorButton = styled('a', {
 )
 
 export function AnchorButton({
+  eventLog = true,
   ...props
-}: React.ComponentProps<typeof StyledAnchorButton>) {
+}: { eventLog?: boolean } & React.ComponentProps<typeof StyledAnchorButton>) {
   const onClick = props?.onClick
 
   const wrappedOnClick = React.useMemo(
     () =>
-      wrapHandlerWithLog({
-        name: 'ANCHOR_BUTTON_CLICK',
-        handler: onClick,
-        addToPayload: event => ({
-          href: event?.target?.getAttribute('href'),
-        }),
-      }),
-    [onClick],
+      eventLog
+        ? wrapHandlerWithLog({
+            name: 'ANCHOR_BUTTON_CLICK',
+            handler: onClick,
+            addToPayload: event => ({
+              href: event?.target?.getAttribute('href'),
+            }),
+          })
+        : onClick,
+    [onClick, eventLog],
   )
 
   return <StyledAnchorButton {...props} onClick={wrappedOnClick} />

--- a/packages/primitives/src/Button/AnchorButton.tsx
+++ b/packages/primitives/src/Button/AnchorButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import styled from '@emotion/styled'
 import { base, buttonVariant } from './Button'
-import { addToPayload } from '../Link/Link'
+import { addHrefToPayload } from '../Link/Link'
 import {
   shouldForwardProp,
   sx,
@@ -47,8 +47,8 @@ export const AnchorButton = React.forwardRef<
   const wrappedOnClick = useWrappedEventHandler({
     name: 'ANCHOR_BUTTON_CLICK',
     handler: props.onClick,
-    isActive: eventLog,
-    addToPayload,
+    isLoggingEventsActive: eventLog,
+    addToPayload: addHrefToPayload,
   })
 
   return <StyledAnchorButton {...props} ref={ref} onClick={wrappedOnClick} />

--- a/packages/primitives/src/Button/AnchorButton.tsx
+++ b/packages/primitives/src/Button/AnchorButton.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 import styled from '@emotion/styled'
 import { base, buttonVariant } from './Button'
+import { addToPayload } from '../Link/Link'
 import {
   shouldForwardProp,
   sx,
@@ -8,7 +9,7 @@ import {
   SystemProps,
   VariantProps,
 } from '@kodiak-ui/core'
-import { wrapHandlerWithLog } from '@kodiak-ui/hooks/use-event-logger'
+import { useWrappedEventHandler } from '@kodiak-ui/hooks/use-event-logger'
 
 export type AnchorButtonProps = React.DetailedHTMLProps<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
@@ -43,21 +44,12 @@ export function AnchorButton({
   eventLog = true,
   ...props
 }: { eventLog?: boolean } & React.ComponentProps<typeof StyledAnchorButton>) {
-  const onClick = props?.onClick
-
-  const wrappedOnClick = React.useMemo(
-    () =>
-      eventLog
-        ? wrapHandlerWithLog({
-            name: 'ANCHOR_BUTTON_CLICK',
-            handler: onClick,
-            addToPayload: event => ({
-              href: event?.target?.getAttribute('href'),
-            }),
-          })
-        : onClick,
-    [onClick, eventLog],
-  )
+  const wrappedOnClick = useWrappedEventHandler({
+    name: 'ANCHOR_BUTTON_CLICK',
+    handler: props.onClick,
+    isActive: eventLog,
+    addToPayload,
+  })
 
   return <StyledAnchorButton {...props} onClick={wrappedOnClick} />
 }

--- a/packages/primitives/src/Button/AnchorButton.tsx
+++ b/packages/primitives/src/Button/AnchorButton.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import styled from '@emotion/styled'
 import { base, buttonVariant } from './Button'
 import {
@@ -7,6 +8,7 @@ import {
   SystemProps,
   VariantProps,
 } from '@kodiak-ui/core'
+import { wrapHandlerWithLog } from '@kodiak-ui/hooks/use-event-logger'
 
 export type AnchorButtonProps = React.DetailedHTMLProps<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
@@ -18,7 +20,7 @@ export type AnchorButtonProps = React.DetailedHTMLProps<
 /**
  * AnchorButton primitive component
  */
-export const AnchorButton = styled('a', {
+export const StyledAnchorButton = styled('a', {
   shouldForwardProp,
 })<AnchorButtonProps>(
   {
@@ -36,3 +38,23 @@ export const AnchorButton = styled('a', {
   ...systemProps,
   sx,
 )
+
+export function AnchorButton({
+  ...props
+}: React.ComponentProps<typeof StyledAnchorButton>) {
+  const onClick = props?.onClick
+
+  const wrappedOnClick = React.useMemo(
+    () =>
+      wrapHandlerWithLog({
+        name: 'ANCHOR_BUTTON_CLICK',
+        handler: onClick,
+        addToPayload: event => ({
+          href: event?.target?.getAttribute('href'),
+        }),
+      }),
+    [onClick],
+  )
+
+  return <StyledAnchorButton {...props} onClick={wrappedOnClick} />
+}

--- a/packages/primitives/src/Button/AnchorButton.tsx
+++ b/packages/primitives/src/Button/AnchorButton.tsx
@@ -40,10 +40,10 @@ export const StyledAnchorButton = styled('a', {
   sx,
 )
 
-export function AnchorButton({
-  eventLog = true,
-  ...props
-}: { eventLog?: boolean } & React.ComponentProps<typeof StyledAnchorButton>) {
+export const AnchorButton = React.forwardRef<
+  HTMLAnchorElement,
+  { eventLog?: boolean } & React.ComponentProps<typeof StyledAnchorButton>
+>(({ eventLog = true, ...props }, ref) => {
   const wrappedOnClick = useWrappedEventHandler({
     name: 'ANCHOR_BUTTON_CLICK',
     handler: props.onClick,
@@ -51,5 +51,5 @@ export function AnchorButton({
     addToPayload,
   })
 
-  return <StyledAnchorButton {...props} onClick={wrappedOnClick} />
-}
+  return <StyledAnchorButton {...props} ref={ref} onClick={wrappedOnClick} />
+})

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -82,7 +82,9 @@ export type ButtonEvent = {
   }
 }
 
-export function Button({ ...props }) {
+export function Button({
+  ...props
+}: React.ComponentProps<typeof StyledButton>) {
   const onClick = props?.onClick
 
   const wrappedOnClick = React.useMemo(

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -92,7 +92,7 @@ export const Button = React.forwardRef<
   const wrappedOnClick = useWrappedEventHandler({
     name: 'BUTTON_CLICK',
     handler: props.onClick,
-    isActive: eventLog,
+    isLoggingEventsActive: eventLog,
   })
 
   return <StyledButton {...props} ref={ref} onClick={wrappedOnClick} />

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import {
   variant,
   sx,
@@ -10,6 +11,7 @@ import {
   SerializedStyles,
   styled,
 } from '@kodiak-ui/core'
+import { wrapHandlerWithLog } from '@kodiak-ui/hooks/use-event-logger'
 import { base as baseProp, BaseProps } from '../Box'
 
 /**
@@ -52,7 +54,7 @@ export type ButtonProps = React.DetailedHTMLProps<
 /**
  * Button primitive component
  */
-export const Button = styled('button', {
+export const StyledButton = styled('button', {
   shouldForwardProp,
 })<ButtonProps>(
   {
@@ -71,3 +73,22 @@ export const Button = styled('button', {
   ...systemProps,
   sx,
 )
+
+export type ButtonEvent = {
+  name: string
+  payload: {
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+    sourceLabel: string
+  }
+}
+
+export function Button({ ...props }) {
+  const onClick = props?.onClick
+
+  const wrappedOnClick = React.useMemo(
+    () => wrapHandlerWithLog({ name: 'BUTTON_CLICK', handler: onClick }),
+    [onClick], // eslint prefers a function so that it can check the dependencies statically so we useMemo instead of useCallback
+  )
+
+  return <StyledButton {...props} onClick={wrappedOnClick} />
+}

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -82,15 +82,15 @@ export type ButtonEvent = {
   }
 }
 
-export function Button({
-  eventLog = true,
-  ...props
-}: { eventLog?: boolean } & React.ComponentProps<typeof StyledButton>) {
+export const Button = React.forwardRef<
+  HTMLButtonElement,
+  { eventLog?: boolean } & React.ComponentProps<typeof StyledButton>
+>(({ eventLog = true, ...props }, ref) => {
   const wrappedOnClick = useWrappedEventHandler({
     name: 'BUTTON_CLICK',
     handler: props.onClick,
     isActive: eventLog,
   })
 
-  return <StyledButton {...props} onClick={wrappedOnClick} />
-}
+  return <StyledButton {...props} ref={ref} onClick={wrappedOnClick} />
+})

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -11,7 +11,7 @@ import {
   SerializedStyles,
   styled,
 } from '@kodiak-ui/core'
-import { wrapHandlerWithLog } from '@kodiak-ui/hooks/use-event-logger'
+import { useWrappedEventHandler } from '@kodiak-ui/hooks/use-event-logger'
 import { base as baseProp, BaseProps } from '../Box'
 
 /**
@@ -86,15 +86,11 @@ export function Button({
   eventLog = true,
   ...props
 }: { eventLog?: boolean } & React.ComponentProps<typeof StyledButton>) {
-  const onClick = props?.onClick
-
-  const wrappedOnClick = React.useMemo(
-    () =>
-      eventLog
-        ? wrapHandlerWithLog({ name: 'BUTTON_CLICK', handler: onClick })
-        : onClick,
-    [onClick, eventLog], // eslint prefers a function so that it can check the dependencies statically so we useMemo instead of useCallback
-  )
+  const wrappedOnClick = useWrappedEventHandler({
+    name: 'BUTTON_CLICK',
+    handler: props.onClick,
+    isActive: eventLog,
+  })
 
   return <StyledButton {...props} onClick={wrappedOnClick} />
 }

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -84,7 +84,10 @@ export type ButtonEvent = {
 
 export const Button = React.forwardRef<
   HTMLButtonElement,
-  { eventLog?: boolean } & React.ComponentProps<typeof StyledButton>
+  { eventLog?: boolean } & Omit<
+    React.ComponentProps<typeof StyledButton>,
+    'ref'
+  >
 >(({ eventLog = true, ...props }, ref) => {
   const wrappedOnClick = useWrappedEventHandler({
     name: 'BUTTON_CLICK',

--- a/packages/primitives/src/Button/Button.tsx
+++ b/packages/primitives/src/Button/Button.tsx
@@ -83,13 +83,17 @@ export type ButtonEvent = {
 }
 
 export function Button({
+  eventLog = true,
   ...props
-}: React.ComponentProps<typeof StyledButton>) {
+}: { eventLog?: boolean } & React.ComponentProps<typeof StyledButton>) {
   const onClick = props?.onClick
 
   const wrappedOnClick = React.useMemo(
-    () => wrapHandlerWithLog({ name: 'BUTTON_CLICK', handler: onClick }),
-    [onClick], // eslint prefers a function so that it can check the dependencies statically so we useMemo instead of useCallback
+    () =>
+      eventLog
+        ? wrapHandlerWithLog({ name: 'BUTTON_CLICK', handler: onClick })
+        : onClick,
+    [onClick, eventLog], // eslint prefers a function so that it can check the dependencies statically so we useMemo instead of useCallback
   )
 
   return <StyledButton {...props} onClick={wrappedOnClick} />

--- a/packages/primitives/src/Button/__tests__/AnchorButton.spec.tsx
+++ b/packages/primitives/src/Button/__tests__/AnchorButton.spec.tsx
@@ -41,6 +41,7 @@ describe('AnchorButton', () => {
 
       <a
         className="emotion-0"
+        onClick={[Function]}
       >
         Rendering AnchorButton
       </a>
@@ -88,6 +89,7 @@ describe('AnchorButton', () => {
 
       <a
         className="emotion-0"
+        onClick={[Function]}
       >
         Default AnchorButton
       </a>
@@ -130,6 +132,7 @@ describe('AnchorButton', () => {
 
       <a
         className="emotion-0"
+        onClick={[Function]}
       >
         Default AnchorButton
       </a>

--- a/packages/primitives/src/Button/__tests__/Button.spec.tsx
+++ b/packages/primitives/src/Button/__tests__/Button.spec.tsx
@@ -2,6 +2,10 @@ import * as React from 'react'
 import serializer from 'jest-emotion'
 import renderer from 'react-test-renderer'
 import { Button } from '../Button'
+import { renderHook } from '@testing-library/react-hooks'
+import { render, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { useEventLoggerReducers } from '@kodiak-ui/hooks/use-event-logger'
 
 expect.addSnapshotSerializer(serializer)
 
@@ -38,6 +42,7 @@ describe('Button', () => {
 
       <button
         className="emotion-0"
+        onClick={[Function]}
       >
         Rendering button
       </button>
@@ -83,6 +88,7 @@ describe('Button', () => {
 
       <button
         className="emotion-0"
+        onClick={[Function]}
       >
         Default button
       </button>
@@ -122,9 +128,45 @@ describe('Button', () => {
 
       <button
         className="emotion-0"
+        onClick={[Function]}
       >
         Default button
       </button>
     `)
+  })
+
+  it('should logging events', () => {
+    const myOnClickHandler = jest.fn()
+    let log = []
+    renderHook(() =>
+      useEventLoggerReducers({
+        initialEventReducers: [
+          event => {
+            log = [...log, event]
+            return event
+          },
+        ],
+      }),
+    )
+
+    const { getByText } = render(
+      <Button onClick={myOnClickHandler}>Click me</Button>,
+    )
+
+    fireEvent.click(getByText('Click me'))
+
+    expect(myOnClickHandler).toBeCalledTimes(1)
+    expect(log.length).toBe(1)
+
+    const unloggedOnClick = jest.fn()
+    const { getByText: getByText2 } = render(
+      <Button onClick={unloggedOnClick} eventLog={false}>
+        No logging
+      </Button>,
+    )
+
+    fireEvent.click(getByText2('No logging'))
+    expect(unloggedOnClick).toBeCalledTimes(1)
+    expect(log.length).toBe(1)
   })
 })

--- a/packages/primitives/src/Link/Link.tsx
+++ b/packages/primitives/src/Link/Link.tsx
@@ -34,10 +34,10 @@ export function addToPayload(event) {
   }
 }
 
-export function Link({
-  eventLog = true,
-  ...props
-}: { eventLog?: boolean } & React.ComponentProps<typeof StyledLink>) {
+export const Link = React.forwardRef<
+  HTMLAnchorElement,
+  { eventLog?: boolean } & React.ComponentProps<typeof StyledLink>
+>(({ eventLog = true, ...props }, ref) => {
   const wrappedOnClick = useWrappedEventHandler({
     name: 'LINK_CLICK',
     handler: props.onClick,
@@ -45,5 +45,5 @@ export function Link({
     addToPayload,
   })
 
-  return <StyledLink {...props} onClick={wrappedOnClick} />
-}
+  return <StyledLink {...props} ref={ref} onClick={wrappedOnClick} />
+})

--- a/packages/primitives/src/Link/Link.tsx
+++ b/packages/primitives/src/Link/Link.tsx
@@ -28,19 +28,24 @@ export const StyledLink = styled('a')<LinkProps>(
   sx,
 )
 
-export function Link({ ...props }: React.ComponentProps<typeof StyledLink>) {
+export function Link({
+  eventLog = true,
+  ...props
+}: { eventLog?: boolean } & React.ComponentProps<typeof StyledLink>) {
   const onClick = props?.onClick
 
   const wrappedOnClick = React.useMemo(
     () =>
-      wrapHandlerWithLog({
-        name: 'LINK_CLICK',
-        handler: onClick,
-        addToPayload: event => ({
-          href: event?.target?.getAttribute('href'),
-        }),
-      }),
-    [onClick],
+      eventLog
+        ? wrapHandlerWithLog({
+            name: 'LINK_CLICK',
+            handler: onClick,
+            addToPayload: event => ({
+              href: event?.target?.getAttribute('href'),
+            }),
+          })
+        : onClick,
+    [onClick, eventLog],
   )
 
   return <StyledLink {...props} onClick={wrappedOnClick} />

--- a/packages/primitives/src/Link/Link.tsx
+++ b/packages/primitives/src/Link/Link.tsx
@@ -28,7 +28,7 @@ export const StyledLink = styled('a')<LinkProps>(
   sx,
 )
 
-export function addToPayload(event) {
+export function addHrefToPayload(event) {
   return {
     href: event?.target?.getAttribute('href'),
   }
@@ -41,8 +41,8 @@ export const Link = React.forwardRef<
   const wrappedOnClick = useWrappedEventHandler({
     name: 'LINK_CLICK',
     handler: props.onClick,
-    isActive: eventLog,
-    addToPayload,
+    isLoggingEventsActive: eventLog,
+    addToPayload: addHrefToPayload,
   })
 
   return <StyledLink {...props} ref={ref} onClick={wrappedOnClick} />

--- a/packages/primitives/src/Link/Link.tsx
+++ b/packages/primitives/src/Link/Link.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import styled from '@emotion/styled'
 import {
   sx,
@@ -6,6 +7,7 @@ import {
   systemProps,
   SystemProps,
 } from '@kodiak-ui/core'
+import { wrapHandlerWithLog } from '@kodiak-ui/hooks/use-event-logger'
 import { base, BaseProps } from '../Box'
 
 type LinkProps = VariantProps &
@@ -13,7 +15,7 @@ type LinkProps = VariantProps &
   BaseProps &
   React.HTMLAttributes<HTMLAnchorElement>
 
-export const Link = styled('a')<LinkProps>(
+export const StyledLink = styled('a')<LinkProps>(
   {
     boxSizing: 'border-box',
     margin: 0,
@@ -25,3 +27,21 @@ export const Link = styled('a')<LinkProps>(
   ...systemProps,
   sx,
 )
+
+export function Link({ ...props }: React.ComponentProps<typeof StyledLink>) {
+  const onClick = props?.onClick
+
+  const wrappedOnClick = React.useMemo(
+    () =>
+      wrapHandlerWithLog({
+        name: 'LINK_CLICK',
+        handler: onClick,
+        addToPayload: event => ({
+          href: event?.target?.getAttribute('href'),
+        }),
+      }),
+    [onClick],
+  )
+
+  return <StyledLink {...props} onClick={wrappedOnClick} />
+}

--- a/packages/primitives/src/Link/Link.tsx
+++ b/packages/primitives/src/Link/Link.tsx
@@ -7,7 +7,7 @@ import {
   systemProps,
   SystemProps,
 } from '@kodiak-ui/core'
-import { wrapHandlerWithLog } from '@kodiak-ui/hooks/use-event-logger'
+import { useWrappedEventHandler } from '@kodiak-ui/hooks/use-event-logger'
 import { base, BaseProps } from '../Box'
 
 type LinkProps = VariantProps &
@@ -28,25 +28,22 @@ export const StyledLink = styled('a')<LinkProps>(
   sx,
 )
 
+export function addToPayload(event) {
+  return {
+    href: event?.target?.getAttribute('href'),
+  }
+}
+
 export function Link({
   eventLog = true,
   ...props
 }: { eventLog?: boolean } & React.ComponentProps<typeof StyledLink>) {
-  const onClick = props?.onClick
-
-  const wrappedOnClick = React.useMemo(
-    () =>
-      eventLog
-        ? wrapHandlerWithLog({
-            name: 'LINK_CLICK',
-            handler: onClick,
-            addToPayload: event => ({
-              href: event?.target?.getAttribute('href'),
-            }),
-          })
-        : onClick,
-    [onClick, eventLog],
-  )
+  const wrappedOnClick = useWrappedEventHandler({
+    name: 'LINK_CLICK',
+    handler: props.onClick,
+    isActive: eventLog,
+    addToPayload,
+  })
 
   return <StyledLink {...props} onClick={wrappedOnClick} />
 }

--- a/packages/primitives/src/Link/__tests__/Link.spec.tsx
+++ b/packages/primitives/src/Link/__tests__/Link.spec.tsx
@@ -18,6 +18,7 @@ describe('Link', () => {
       <a
         className="emotion-0"
         href="#"
+        onClick={[Function]}
       >
         Rendering a element
       </a>
@@ -37,6 +38,7 @@ describe('Link', () => {
 
       <a
         className="emotion-0"
+        onClick={[Function]}
       >
         A link
       </a>
@@ -64,6 +66,7 @@ describe('Link', () => {
         className="emotion-0"
         color="red"
         href="https://jilt.com"
+        onClick={[Function]}
       >
         jilt.com
       </a>

--- a/packages/select/src/SelectButton.tsx
+++ b/packages/select/src/SelectButton.tsx
@@ -12,9 +12,12 @@ export interface SelectButtonProps
   type?: 'button' | 'reset' | 'submit' | undefined
 }
 
-export const SelectButton = React.forwardRef(function SelectButton(
-  { children, isOpen, variantKey = 'selects', ...props }: SelectButtonProps,
-  ref: React.Ref<HTMLButtonElement>,
+export const SelectButton = React.forwardRef<
+  HTMLButtonElement,
+  SelectButtonProps
+>(function SelectButton(
+  { children, isOpen, variantKey = 'selects', ...props },
+  ref,
 ) {
   return (
     <Button
@@ -29,7 +32,7 @@ export const SelectButton = React.forwardRef(function SelectButton(
         minWidth: '184px',
         textAlign: 'left',
       }}
-      ref={ref}
+      ref={ref as any} // Legacy ref possibly something related to https://github.com/downshift-js/downshift/issues/718
       variantKey={variantKey}
       {...props}
     >

--- a/packages/select/src/__tests__/Select.spec.tsx
+++ b/packages/select/src/__tests__/Select.spec.tsx
@@ -156,6 +156,7 @@ describe('Text', () => {
         </label>
         <button
           className="emotion-2"
+          onClick={[Function]}
         >
           Filter:
           <svg

--- a/packages/storybook/src/hooks/useEventLogger.stories.tsx
+++ b/packages/storybook/src/hooks/useEventLogger.stories.tsx
@@ -71,21 +71,27 @@ export function LogEvent() {
             <Route path="/pricing">Pricing</Route>
             <Route path="/home">Home</Route>
           </Switch>
-          <Button
-            aria-label="aria-label for the event target"
-            onMouseOver={e => {
-              const target = e.target as HTMLButtonElement
-              logEvent({
-                name: 'MOUSE_OVER',
-                payload: {
-                  source:
-                    target?.getAttribute('aria-label') || target.textContent,
-                },
-              })
-            }}
-          >
-            Fire a mouse over event
-          </Button>
+          <Grid sx={{ maxWidth: '200px', gap: 4 }}>
+            <Button
+              aria-label="aria-label for the event target"
+              onMouseOver={e => {
+                const target = e.target as HTMLButtonElement
+                logEvent({
+                  name: 'MOUSE_OVER',
+                  payload: {
+                    sourceLabel:
+                      target?.getAttribute('aria-label') || target.textContent,
+                  },
+                })
+              }}
+            >
+              Fire a mouse over event
+            </Button>
+
+            <Button>
+              <Text>Button with no aria-label</Text>
+            </Button>
+          </Grid>
         </Grid>
 
         <Grid sx={{ mt: 4 }}>

--- a/packages/storybook/src/hooks/useEventLogger.stories.tsx
+++ b/packages/storybook/src/hooks/useEventLogger.stories.tsx
@@ -48,7 +48,7 @@ export function LogEvent() {
                 ...payload,
                 id: ++id,
                 currentPrice,
-                role: sourceEvent.target?.getAttribute('role'),
+                role: sourceEvent?.target?.getAttribute('role'),
               },
             }
           },

--- a/packages/storybook/src/hooks/useEventLogger.stories.tsx
+++ b/packages/storybook/src/hooks/useEventLogger.stories.tsx
@@ -13,7 +13,14 @@ import {
   BrowserRouter,
   useLocation,
 } from 'react-router-dom'
-import { Box, Button, Grid, Text } from '@kodiak-ui/primitives'
+import {
+  Box,
+  Button,
+  AnchorButton,
+  Grid,
+  Text,
+  Link as KodiakLink,
+} from '@kodiak-ui/primitives'
 
 export default { title: 'Hooks/useEventLogger' }
 
@@ -66,6 +73,10 @@ export function LogEvent() {
           </Text>
           <Link to="/home">Home</Link>
           <Link to="/pricing">Pricing</Link>
+          <KodiakLink href="https://jilt.com" target="_blank">
+            External link
+          </KodiakLink>
+
           <Text>Current iframe route: </Text>
           <Switch>
             <Route path="/pricing">Pricing</Route>
@@ -91,6 +102,14 @@ export function LogEvent() {
             <Button>
               <Text>Button with no aria-label</Text>
             </Button>
+
+            <AnchorButton
+              variant="secondary"
+              href="https://app.jilt.com"
+              target="_blank"
+            >
+              Anchor button
+            </AnchorButton>
           </Grid>
         </Grid>
 

--- a/packages/storybook/src/hooks/useEventLogger.stories.tsx
+++ b/packages/storybook/src/hooks/useEventLogger.stories.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {
   useEventLoggerReducers,
   useEventLogger,
+  Event,
 } from '@kodiak-ui/hooks/use-event-logger'
 import { useEventLogRoute } from '@kodiak-ui/hooks'
 import {
@@ -36,8 +37,20 @@ export function LogEvent() {
       {
         initialEventReducers: [
           // Add an id to the event
-          event => {
-            return { ...event, id: ++id, currentPrice }
+          (event: Event) => {
+            // We get rid of the source event before console logging
+            // because it is a synthetic event
+            // but we still have access to it
+            const { sourceEvent, ...payload } = event?.payload
+            return {
+              ...event,
+              payload: {
+                ...payload,
+                id: ++id,
+                currentPrice,
+                role: sourceEvent.target?.getAttribute('role'),
+              },
+            }
           },
           // Console.log the event
           event => {
@@ -107,6 +120,7 @@ export function LogEvent() {
               variant="secondary"
               href="https://app.jilt.com"
               target="_blank"
+              onClick={event => console.info('Clicked the anchor button')}
             >
               Anchor button
             </AnchorButton>


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

Add button logging enabled by default that dispatches to the `useEventLog` hook.  The event logging can be disabled by passing `eventLog={false}` or completely ignoring the event log item.



<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch62987](https://app.clubhouse.io/skyverge/story/62987/add-button-event-logging-to-kodiak)

## :vertical_traffic_light: Acceptance criteria

- [x] When `eventLog={false}` the event is not logged
- [x] When the button is used, the events are sent to the event log for processing


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

