### PR TITLE
Add conditional chaining to useOnClickOutside

### DIFF
--- a/packages/hooks/src/useOnClickOutside.ts
+++ b/packages/hooks/src/useOnClickOutside.ts
@@ -21,13 +21,13 @@ export const useOnClickOutside = ({
       // Do nothing if clicking ref's element or descendent elements
       if (
         !ref.current ||
-        ref.current.contains(event.target) ||
-        (refException && refException.current.contains(event.target))
+        ref?.current?.contains?.(event.target) ||
+        refException?.current?.contains?.(event.target)
       ) {
         return
       }
 
-      savedHandler && savedHandler.current && savedHandler.current(event)
+      savedHandler?.current?.(event)
     }
 
     document.addEventListener('mousedown', listener)


### PR DESCRIPTION
Fixes the click if refException.current is `null`.

**Main Story:** [ch64567](https://app.clubhouse.io/skyverge/story/64567/adds-the-active-inactive-toggle-action-on-the-orderreceiptssingle-page)

<a name="details"></a>

## Details

<!-- Additional details (especially implementation considerations) to expand on the summary, if needed. -->

This PR will address changes to the following:

- [ ] Components
- [x] Hooks

<a name="qa"></a>

## Acceptance Crtieria

<!-- Required section. List relevant scenarios for this branch and what needs to be user-tested in each case: -->

- [x] tooltip works
- [x] menu on click outside closes the menu
