### PR TITLE
add optional chaining to useMenu keyboard handler

### DIFF
--- a/packages/menu/src/useMenu.ts
+++ b/packages/menu/src/useMenu.ts
@@ -294,7 +294,7 @@ export function useMenu({
     target: menuRef.current,
     handler: () => {
       const handler = itemHandlersRef.current[activeItem] as () => void
-      handler()
+      handler?.()
     },
   })
 


### PR DESCRIPTION
Fixes an error being thrown when the user uses the keyboard and there's no menu handler