### PR TITLE
Add as type

### DIFF
--- a/packages/primitives/src/Box/Box.tsx
+++ b/packages/primitives/src/Box/Box.tsx
@@ -8,6 +8,10 @@ import {
   sx,
   _variant,
 } from 'kodiak-ui'
+import type {
+  OverridableComponent,
+  OverrideProps,
+} from '../types/OverridableComponent'
 
 function base({ theme, __base, base }) {
   const styles = base ? getComponentBase(base ? base : 'box')(theme) : null
@@ -27,18 +31,24 @@ const boxVariant = ({ variant: variantProp, variantKey, variants, theme }) => {
   return _variant({ variant: variantProp, theme, variantKey, variants })
 }
 
-export type BoxProps = React.PropsWithChildren<
-  KodiakUIProps & {
-    ref?: any
-    as?: string
-  } & React.AllHTMLAttributes<HTMLElement>
->
-
 /**
  * Box primitive component which is the base component for
  * all components in Kodiak
  */
-export const Box = styled('div')<BoxProps>(
+
+export interface BoxTypeMap<P = unknown, D extends React.ElementType = 'div'> {
+  props: P & React.PropsWithChildren<KodiakUIProps>
+  defaultComponent: D
+}
+
+type BoxProps<
+  D extends React.ElementType = BoxTypeMap['defaultComponent'],
+  P = unknown
+> = OverrideProps<BoxTypeMap<P, D>, D>
+
+type BoxComponent = OverridableComponent<BoxTypeMap>
+
+export const Box: BoxComponent = styled('div')<BoxProps>(
   {
     boxSizing: 'border-box',
     margin: 0,

--- a/packages/primitives/src/Box/Box.tsx
+++ b/packages/primitives/src/Box/Box.tsx
@@ -41,14 +41,14 @@ export interface BoxTypeMap<P = unknown, D extends React.ElementType = 'div'> {
   defaultComponent: D
 }
 
-type BoxProps<
+export type BoxProps<
   D extends React.ElementType = BoxTypeMap['defaultComponent'],
   P = unknown
 > = OverrideProps<BoxTypeMap<P, D>, D>
 
-type BoxComponent = OverridableComponent<BoxTypeMap>
+// export type BoxComponent = OverridableComponent<BoxTypeMap>
 
-export const Box: BoxComponent = styled('div')<BoxProps>(
+export const Box: OverridableComponent<BoxTypeMap> = styled('div')<BoxProps>(
   {
     boxSizing: 'border-box',
     margin: 0,

--- a/packages/primitives/src/Flex/Flex.tsx
+++ b/packages/primitives/src/Flex/Flex.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react'
-import { Box, BoxProps } from '../Box'
+import { Box } from '../Box'
+import styled from '@emotion/styled'
 
-export const Flex = React.forwardRef(
-  ({ __base, ...props }: BoxProps, ref: any) => (
-    <Box ref={ref} __base={{ display: 'flex', ...__base }} {...props} />
-  ),
-)
+export const Flex = styled(Box)({
+  display: 'flex',
+})

--- a/packages/primitives/src/Grid/Grid.tsx
+++ b/packages/primitives/src/Grid/Grid.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react'
-import { Box, BoxProps } from '../Box'
+import { Box } from '../Box'
+import styled from '@emotion/styled'
 
-export const Grid = React.forwardRef(
-  ({ __base, ...props }: BoxProps, ref: any) => (
-    <Box ref={ref} __base={{ display: 'grid', ...__base }} {...props} />
-  ),
-)
+export const Grid = styled(Box)({
+  display: 'grid',
+})

--- a/packages/primitives/src/Nav/Nav.tsx
+++ b/packages/primitives/src/Nav/Nav.tsx
@@ -1,12 +1,15 @@
 import * as React from 'react'
-import { Box } from '../Box'
+import { Box, BoxProps } from '../Box'
 
-type NavProps = {
-  children: React.ReactNode
-  'aria-label'?: string
-  dismissLabel?: string
-  onDismiss?: () => void
-} & React.ComponentProps<typeof Box>
+type NavProps = BoxProps<
+  'ul',
+  {
+    children?: React.ReactNode
+    'aria-label'?: string
+    dismissLabel?: string
+    onDismiss?: () => void
+  }
+>
 
 export const Nav = React.forwardRef<HTMLUListElement, NavProps>(function Menu(
   { children, variantKey = 'navs', variant, __base, ...props },
@@ -21,8 +24,8 @@ export const Nav = React.forwardRef<HTMLUListElement, NavProps>(function Menu(
           padding: 0,
           ...__base,
         }}
-        ref={forwardedRef as any}
         as="ul"
+        ref={forwardedRef}
         variantKey={variantKey}
         variant={variant}
         {...props}

--- a/packages/primitives/src/Nav/NavItem.tsx
+++ b/packages/primitives/src/Nav/NavItem.tsx
@@ -1,27 +1,19 @@
 import * as React from 'react'
-import { Box } from '../Box'
+import { Box, BoxProps } from '../Box'
 
-type NavItemProps = {
-  children: React.ReactNode
-} & React.ComponentProps<typeof Box>
+type NavItemProps = BoxProps<'li', unknown>
 
 export const NavItem = React.forwardRef<HTMLLIElement, NavItemProps>(
   function NavItem(
-    {
-      children,
-      variantKey = 'navs',
-      variant = 'navItem',
-      as: renderAs = 'li',
-      ...props
-    },
+    { children, variantKey = 'navs', variant = 'navItem', ...props },
     forwardedRef,
   ) {
     return (
       <Box
         variantKey={variantKey}
         variant={variant}
-        as={renderAs}
-        ref={forwardedRef as any}
+        as="li"
+        ref={forwardedRef}
         sx={{ cursor: 'pointer', transition: 'all 0.2s ease-in-out' }}
         {...props}
       >

--- a/packages/primitives/src/types/OverridableComponent.d.ts
+++ b/packages/primitives/src/types/OverridableComponent.d.ts
@@ -1,0 +1,65 @@
+// this is https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/OverridableComponent.d.ts
+// but component has been changed to `as`
+import { SxStyleProp } from 'kodiak-ui'
+
+/**
+ * A component whose root component can be controlled via a `component` prop.
+ *
+ * Adjusts valid props based on the type of `component`.
+ */
+export interface OverridableComponent<M extends OverridableTypeMap> {
+  <C extends React.ElementType>(
+    props: {
+      /**
+       * The component used for the root node.
+       * Either a string to use a HTML element or a component.
+       */
+      as?: C
+      children?: React.ReactNode
+    } & OverrideProps<M, C>,
+  ): JSX.Element
+  (props: DefaultComponentProps<M>): JSX.Element
+}
+
+/**
+ * Props of the component if `component={Component}` is used.
+ */
+// prettier-ignore
+export type OverrideProps<
+  M extends OverridableTypeMap,
+  C extends React.ElementType
+> = (
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<C>, keyof BaseProps<M>>
+);
+
+/**
+ * Props if `component={Component}` is NOT used.
+ */
+// prettier-ignore
+export type DefaultComponentProps<M extends OverridableTypeMap> =
+  & BaseProps<M>
+  & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
+
+/**
+ * Props defined on the component (+ common material-ui props).
+ */
+// prettier-ignore
+export type BaseProps<M extends OverridableTypeMap> =
+  & M['props']
+  & CommonProps;
+
+/**
+ * Props that are valid for material-ui components.
+ */
+// each component declares it's classes in a separate interface for proper JSDOC.
+export interface CommonProps {
+  className?: string
+  style?: React.CSSProperties
+  sx?: SxStyleProp
+}
+
+export interface OverridableTypeMap {
+  props: unknown
+  defaultComponent: React.ElementType
+}

--- a/packages/storybook/src/primitives/Box/Box.stories.tsx
+++ b/packages/storybook/src/primitives/Box/Box.stories.tsx
@@ -17,17 +17,28 @@ export function initial() {
   )
 }
 
-export function asProp() {
+export function AsProp() {
+  const aRef = React.useRef<HTMLAnchorElement>(null)
   return (
-    <Box
-      as="main"
-      sx={{
-        fontFamily: 'body',
-        fontWeight: 'bold',
-        padding: 5,
-      }}
-    >
-      Renders the Box as a Main HTML element
+    <Box>
+      <Box
+        as="main"
+        sx={{
+          fontFamily: 'body',
+          fontWeight: 'bold',
+          padding: 5,
+        }}
+      >
+        Renders the Box as a Main HTML element
+      </Box>
+      <Box
+        as="a"
+        href="#"
+        sx={{ textDecoration: 'underline', padding: 5 }}
+        ref={aRef}
+      >
+        This is a Box as an anchor tag and a Ref
+      </Box>
     </Box>
   )
 }

--- a/packages/storybook/src/primitives/Box/Box.stories.tsx
+++ b/packages/storybook/src/primitives/Box/Box.stories.tsx
@@ -17,6 +17,15 @@ export function initial() {
   )
 }
 
+function CustomComponent({
+  customMessage,
+  ...props
+}: {
+  customMessage: string
+}) {
+  return <div {...props}>{customMessage}</div>
+}
+
 export function AsProp() {
   const aRef = React.useRef<HTMLAnchorElement>(null)
   return (
@@ -30,8 +39,6 @@ export function AsProp() {
         }}
       >
         Renders the Box as a Main HTML element
-        <Box>test</Box>
-        <Box>test</Box>
       </Box>
       <Box
         as="a"
@@ -41,6 +48,11 @@ export function AsProp() {
       >
         This is a Box as an anchor tag and a Ref
       </Box>
+      <Box
+        as={CustomComponent}
+        sx={{ color: 'primary', p: 5 }}
+        customMessage={'Custom components can be wrapped and styled as a box'}
+      />
     </Box>
   )
 }

--- a/packages/storybook/src/primitives/Box/Box.stories.tsx
+++ b/packages/storybook/src/primitives/Box/Box.stories.tsx
@@ -30,6 +30,8 @@ export function AsProp() {
         }}
       >
         Renders the Box as a Main HTML element
+        <Box>test</Box>
+        <Box>test</Box>
       </Box>
       <Box
         as="a"


### PR DESCRIPTION
Material UI has done some great work making sure the [`component`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/OverridableComponent.d.ts) type works so it'd be great to adapt it for the `as` property.

[This sandbox ](https://codesandbox.io/s/fast-field-13wbu?file=/src/LinkExample.tsx) has a reduced version of the OverrideableComponent in use.  Apply the same types to some of the base types and see how we can define a component using the same ideas.

closes #120

## Acceptance criteria

- [x] the component types should reflect the same properties available on the `as` which could be a component or a string version of a primitive tag
- [x] additional common types that are on the base type should still be allowed (ie. `sx`)
 
- ❌ forwarding refs with as is easy - the type doesn't seem to support this.  material ui types also have this problem so it would probably take some more advanced typing to `forwardRef` with an `as`. 


```
// currently broken in material ui
import * as React from "react";

import MuiLink, { LinkProps as MuiLinkProps } from "@material-ui/core/Link";

interface LinkPropsBase {
  activeClassName?: string;
  innerRef?: React.Ref<HTMLAnchorElement>;
  naked?: boolean;
}

export type LinkProps = LinkPropsBase & MuiLinkProps & { as?: string };

// A styled version of the Next.js Link component:
// https://nextjs.org/docs/#with-link
const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
  ({ as, ...props }, ref) => <MuiLink {...props} innerRef={ref} />
);

function Test() {
  const aRef = React.useRef<HTMLLIElement>(null);
  return (
    <Link as="li" href="#" ref={aRef}>
      test
    </Link>
  );
}

```