### PR TITLE
Support a closeTimeout prop for useTooltip

### DIFF
--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kodiak-ui/storybook",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "dist/storybook.cjs.js",
   "module": "dist/storybook.esm.js",
   "private": true,

--- a/packages/storybook/src/Tooltip/Tooltip.stories.tsx
+++ b/packages/storybook/src/Tooltip/Tooltip.stories.tsx
@@ -30,3 +30,31 @@ export function Initial() {
     </Box>
   )
 }
+
+export function WithCloseTimeout() {
+  const { isVisible, register, getTriggerProps, Portal } = useTooltip({
+    placement: 'right',
+    closeTimeout: 5000,
+  })
+
+  return (
+    <Box sx={{ margin: '25%' }}>
+      <Button
+        ref={node => register(node, { trigger: true })}
+        {...getTriggerProps()}
+      >
+        Hover over me
+      </Button>
+      {isVisible && (
+        <Portal>
+          <Tooltip ref={register}>
+            This domain has failed verification. Please contact support.
+            <TooltipArrow
+              ref={(node: HTMLElement) => register(node, { arrow: true })}
+            />
+          </Tooltip>
+        </Portal>
+      )}
+    </Box>
+  )
+}

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kodiak-ui/tooltip",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Tooltip component and hook for displaying small messages on hover",
   "main": "dist/tooltip.cjs.js",
   "module": "dist/tooltip.esm.js",

--- a/packages/tooltip/src/useTooltip.ts
+++ b/packages/tooltip/src/useTooltip.ts
@@ -58,23 +58,23 @@ export function useTooltip({
   const {
     isOpen: isVisible,
     handleOpenPortal,
-    handleClosePortal: closePortal,
+    handleClosePortal: instantlyClosePortal,
     Portal,
     portalRef,
   } = usePortal()
 
-  const handleClosePortal = React.useCallback(
-    function handleClosePortal(event) {
+  const delayedClosePortal = React.useCallback(
+    function delayedClosePortal(event) {
       clearTimeout(timeoutIdRef.current)
       if (closeTimeout === 0) {
-        closePortal(event)
+        instantlyClosePortal(event)
       } else {
         timeoutIdRef.current = setTimeout(() => {
-          return closePortal(event)
+          return instantlyClosePortal(event)
         }, closeTimeout)
       }
     },
-    [closePortal, closeTimeout],
+    [instantlyClosePortal, closeTimeout],
   )
 
   React.useLayoutEffect(
@@ -114,7 +114,7 @@ export function useTooltip({
     ref: portalRef as React.MutableRefObject<Element>,
     refException: triggerRef as React.MutableRefObject<Element>,
     handler: () => {
-      handleClosePortal({})
+      instantlyClosePortal({})
     },
   })
 
@@ -123,7 +123,7 @@ export function useTooltip({
     target: triggerRef.current,
     handler: () => {
       if (isVisible) {
-        handleClosePortal({})
+        instantlyClosePortal({})
       }
     },
   })
@@ -185,12 +185,12 @@ export function useTooltip({
     function getTriggerProps() {
       return {
         onFocus: handleOpenPortal,
-        onBlur: handleClosePortal,
+        onBlur: delayedClosePortal,
         onMouseEnter: handleOpenPortal,
-        onMouseLeave: handleClosePortal,
+        onMouseLeave: delayedClosePortal,
       }
     },
-    [handleOpenPortal, handleClosePortal],
+    [handleOpenPortal, delayedClosePortal],
   )
 
   return {

--- a/packages/tooltip/src/useTooltip.ts
+++ b/packages/tooltip/src/useTooltip.ts
@@ -21,6 +21,7 @@ interface UseTooltipReturn {
 interface UseTooltipProps {
   placement?: Placement
   offset?: [number, number]
+  closeTimeout?: number
 }
 
 type TooltipRef = HTMLElement | null
@@ -44,6 +45,7 @@ export const fromEntries = (entries: any) =>
 export function useTooltip({
   placement = 'top',
   offset = [0, 10],
+  closeTimeout = 0,
 }: UseTooltipProps = {}): UseTooltipReturn {
   const triggerRef = React.useRef<HTMLElement | null>(null)
   const tooltipRef = React.useRef<HTMLElement | null>(null)
@@ -55,10 +57,23 @@ export function useTooltip({
   const {
     isOpen: isVisible,
     handleOpenPortal,
-    handleClosePortal,
+    handleClosePortal: closePortal,
     Portal,
     portalRef,
   } = usePortal()
+
+  const handleClosePortal = React.useCallback(
+    function handleClosePortal(event) {
+      if (closeTimeout === 0) {
+        closePortal(event)
+      } else {
+        setTimeout(() => {
+          return closePortal(event)
+        }, closeTimeout)
+      }
+    },
+    [closePortal, closeTimeout],
+  )
 
   React.useLayoutEffect(
     function initializePopper() {

--- a/packages/tooltip/src/useTooltip.ts
+++ b/packages/tooltip/src/useTooltip.ts
@@ -51,6 +51,7 @@ export function useTooltip({
   const tooltipRef = React.useRef<HTMLElement | null>(null)
   const arrowRef = React.useRef<HTMLElement | null>(null)
   const popperInstanceRef = React.useRef<any>(null)
+  const timeoutIdRef = React.useRef<any>(null)
 
   const id = useId()
 
@@ -64,10 +65,11 @@ export function useTooltip({
 
   const handleClosePortal = React.useCallback(
     function handleClosePortal(event) {
+      clearTimeout(timeoutIdRef.current)
       if (closeTimeout === 0) {
         closePortal(event)
       } else {
-        setTimeout(() => {
+        timeoutIdRef.current = setTimeout(() => {
           return closePortal(event)
         }, closeTimeout)
       }


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

# Summary

Alex suggested that: 

> a closeTimeout that defaults to 0 but can be increased to leave the tooltip visible for a bit longer for these cases where there's something we want to click

This is very helpful when the tooltip contains a link.



<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch67249](https://app.clubhouse.io/skyverge/story/67249/kodiak-tooltip-to-support-a-timeout-before-closing-the-portal)

## :vertical_traffic_light: Acceptance criteria

- [x] There is a story showcasing how to have the tooltip close 5 seconds after the mouse leaves


<a name="implementation-tasks"></a>


## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


### After merge to master

