### PR TITLE
update-kodiak-ui-to-scope-global-styles-to-an-id-instea…

### DIFF
--- a/documentation/docs/variants.md
+++ b/documentation/docs/variants.md
@@ -127,3 +127,19 @@ const { theme } = createDesignSystem({
 ```
 
 Both `secondary` and `lg` variants will be available to all components and can be passed into the `variants` prop for any Kodiak UI component.
+
+## Global definitions
+
+If there are global css to be defined:
+
+```ts
+const { theme } = createDesignSystem({
+  // defaults to body, but could any css selector such as #id or .className
+  globalScope: 'body',
+  global: {
+    p: {
+      fontFamily: 'sans'
+    }
+  }
+})
+```

--- a/packages/kodiak-ui/src/index.ts
+++ b/packages/kodiak-ui/src/index.ts
@@ -70,6 +70,7 @@ export type CreateDesignSystemOptions = {
   variants?: { [key: string]: ThemeUIStyleObject }
   modes?: { [key: string]: any }
   options?: ConfigurationOptions
+  globalScope?: string
 }
 
 export type GlobalStyleObject = {
@@ -163,6 +164,7 @@ export function createDesignSystem({
   components,
   modes,
   options,
+  globalScope = 'body',
 }: CreateDesignSystemOptions = {}): { theme: Theme } {
   const theme = {
     ...options,
@@ -172,8 +174,7 @@ export function createDesignSystem({
     ...variants,
     modes,
     global: {
-      ...themeDefault?.global,
-      ...global,
+      [globalScope]: { ...themeDefault?.global?.body, ...global },
     },
   }
 

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -13,6 +13,12 @@ export const parameters = {
 
 const { theme } = createDesignSystem({
   system,
+  globalScope: 'body',
+  global: {
+    p: {
+      fontFamily: 'body',
+    },
+  },
   modes: {
     dark: {
       colors: {


### PR DESCRIPTION
<!--
* do update this OP regularly with any crucial decisions or details that would otherwise be lost in a lively comment thread below.
* do feel free to exclude any of the below default sections, or include new sections as makes sense for the current job.
* do cut any relevant implementation-focused sections from the main issue for this pull request, e.g. Implementation Tasks, Marketing / Docs Tasks, etc, and paste here to avoid duplication.
-->

The Dashboard styles are bleeding over to the rest of the WP admin. We will need to update kodiak-ui to apply global styles to a scoped ID or class instead of on the body tag.

<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

**Main Story:** [ch76095](https://app.clubhouse.io/skyverge/story/76095/update-kodiak-ui-to-scope-global-styles-to-an-i-d-instead-of-the-body-tag)

The Dashboard styles are bleeding over to the rest of the WP admin. We will need to update kodiak-ui to apply global styles to a scoped ID or class instead of on the body tag.


<a name="implementation-tasks"></a>

## Implementation Tasks

<!-- Copy any relevant implementation tasks from the clubhouse story and add here

- [x] This task has been completed - _done by @someone in sha_
- [ ] This needs to be done
- [ ] This also needs to be done
-->

<a name="qa"></a>

## QA

<!-- Required section. List relevant scenarios for this branch and what needs to be user-tested in each case: -->


<a name="deployment"></a>

## Deployment

### Before merge to master

**Note**: _Code merged to master should be safe to automatically deploy to production as-is._

- [ ] **[QA]** User-testing/quality assurance done


#### This branch adds one or more environment variables

New environment variables should be set _before_ merging to master.

- [ ] Set ENV vars in production: `heroku config:set NAME1=value1 NAME2=value2 -a jilt`


### After merge to master


#### This branch introduces database schema migrations

Ensure the schema migrations follow [our best practices checklist](https://docs.google.com/document/d/12TcV4cRqiFXbocPnkX1BTqNbK38TemKRVbM4pFEZipc/edit).

- [ ] `heroku run rails db:migrate -a jilt`

#### This branch introduces data migrations

- [ ] `heroku run rails data_migrations:your_migration_here -a jilt`
  - For a resource intensive data migration, add `-s performance-m`

