### PR TITLE
Update indeterminate checkbox for selectable tables

### DIFF
--- a/packages/table/src/useRowSelect.tsx
+++ b/packages/table/src/useRowSelect.tsx
@@ -99,7 +99,7 @@ export function useRowSelect<Data>({
               children: (
                 <Checkbox
                   checked={allSelected}
-                  indeterminate={someSelected}
+                  indeterminate={someSelected && !allSelected}
                   onChange={onSelectAll}
                 >
                   <VisuallyHidden>Select all rows</VisuallyHidden>


### PR DESCRIPTION
Ensures that we don't show the indeterminate checkbox when all items are selected.