### PR TITLE
exclude regenerator runtime

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,6 @@
+defaults
+not IE 11
+not kaios 2.5
+not baidu 7
+not op_mini all
+not dead

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,2 @@
 defaults
 not IE 11
-not kaios 2.5
-not baidu 7
-not op_mini all
-not dead

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,7 +2,7 @@ module.exports = function (api) {
   api.cache(true)
 
   const presets = [
-    '@babel/preset-env',
+    ['@babel/preset-env', { exclude: ['@babel/plugin-transform-regenerator'] }],
     '@babel/preset-react',
     '@babel/preset-typescript',
   ]

--- a/packages/hooks/src/useEventLogger.ts
+++ b/packages/hooks/src/useEventLogger.ts
@@ -20,7 +20,7 @@ type EventLoggerStore = {
 // [transform1, transform2] => transform2(transform1(event)) : Event
 export const useEventLoggerStore = create<EventLoggerStore>(
   (set, get): EventLoggerStore => ({
-    logEvent: (event: Event) => {
+    logEvent: async (event: Event) => {
       get().eventReducers?.reduce((event, reducer) => reducer(event), event)
     },
     eventReducers: [],


### PR DESCRIPTION
Just a fix in case we need to exclude regenerator runtime for future builds.  Removing the async that's not required also solves this.  Also reduces browsers list to supported subset.

## Details

[Regenerator runtime](https://github.com/facebook/regenerator) isn't required in most browsers built after 2017 for [async](https://caniuse.com/?search=await) await/generator support from es2015 and since kodiak is a library should be up to the consuming packager to compile .

## QA

- [x] the built file no longer contains regenerator runtime `packages/hooks/use-event-logger/dist/hooks.cjs.prod.js`