### PR TITLE
swap usage of useTranslation with i18next useTranslation

### DIFF
--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -16,6 +16,7 @@
   },
   "gitHead": "2fc0e31f893421d3f807cf5e024c16d6931e813a",
   "dependencies": {
+    "react-i18next": "^11.11.4",
     "resize-observer-polyfill": "^1.5.1",
     "zustand": "^3.2.0"
   },

--- a/packages/hooks/src/useTranslation.ts
+++ b/packages/hooks/src/useTranslation.ts
@@ -1,13 +1,5 @@
-// Simple proxy function as a placeholder for react-i18next
-// until we need the entire translation library this provides a way to
-// start wrapping our texts
 export function t(stringToTranslate: string) {
   return stringToTranslate
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function useTranslation(scope?: string) {
-  return {
-    t,
-  }
-}
+export { useTranslation } from 'react-i18next'

--- a/packages/storybook/src/Dialog/Dialog.stories.tsx
+++ b/packages/storybook/src/Dialog/Dialog.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { component, SharedSx, variant } from 'kodiak-ui'
 import { Dialog, useDialog } from '@kodiak-ui/dialog'
 import { Button, Content, Header, Footer, Text } from '@kodiak-ui/primitives'
+import { useTranslation } from '@kodiak-ui/hooks'
 
 export default { title: 'Dialog', component: Dialog }
 
@@ -41,6 +42,8 @@ variant('scroll', {
 export function Default() {
   const { getDialogProps, handleOpenDialog, handleCloseDialog } = useDialog()
 
+  const { t } = useTranslation()
+
   return (
     <>
       <Button onClick={handleOpenDialog}>Trigger</Button>
@@ -50,9 +53,9 @@ export function Default() {
           <Header variants="dialog-header">Header</Header>
           <Content>
             <Text as="p">
-              Contrary to popular belief, Lorem Ipsum is not simply random text.
-              It has roots in a piece of classical Latin literature from 45 BC,
-              making it over 2000 years old.
+              Contrary to popular belief, {t('Lorem Ipsum')} is not simply
+              random text. It has roots in a piece of classical Latin literature
+              from 45 BC, making it over 2000 years old.
             </Text>
           </Content>
           <Footer variants="dialog-footer">

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,6 +1470,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.14.5":
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
+  integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.3.3", "@babel/template@^7.4.0", "@babel/template@^7.8.6":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -6565,12 +6572,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135:
-  version "1.0.30001230"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
-
-caniuse-lite@^1.0.30001157:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001135, caniuse-lite@^1.0.30001157:
   version "1.0.30001230"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz"
   integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
@@ -10287,6 +10289,13 @@ html-minifier-terser@^5.0.1:
     param-case "^3.0.3"
     relateurl "^0.2.7"
     terser "^4.6.3"
+
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
 
 html-tags@^3.1.0:
   version "3.1.0"
@@ -15889,6 +15898,14 @@ react-hotkeys@2.0.0:
   dependencies:
     prop-types "^15.6.1"
 
+react-i18next@^11.11.4:
+  version "11.11.4"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.11.4.tgz#f6f9a1c827e7a5271377de2bf14db04cb1c9e5ce"
+  integrity sha512-ayWFlu8Sc7GAxW1PzMaPtzq+yiozWMxs0P1WeITNVzXAVRhC0Httkzw/IiODBta6seJRBCLrtUeFUSXhAIxlRg==
+  dependencies:
+    "@babel/runtime" "^7.14.5"
+    html-parse-stringify "^3.0.1"
+
 react-inspector@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.0.tgz#45a325e15f33e595be5356ca2d3ceffb7d6b8c3a"
@@ -18875,6 +18892,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha1-YU9/v42AHwu18GYfWy9XhXUOTwk=
 
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
<!-- Required section. Include a brief high level summary of this pull request: this is what needs to be done. Keep this succinct and to the point and avoid going into the details, save that for the next section. -->

<!-- Required: link to the associated Clubhouse story, or GitHub issue, or Sentry issue, ect. -->
<!-- Note that our convention is to **exclude** the Clubhouse story ID from the PR title. -->

The useTranslation hook can be swapped out directly for our previous hook.  It adds some additional optional parameters and optional returns, but otherwise functions identically if there is no i18next context provided (key values are returned as string values).  This allows us to progressively enhance apps once we give an i18next provider.

note that it does console warn: "You will need to pass in an i18next instance by using initReactI18next" if there's no i18next instance.

<a name="qa"></a>

## Acceptance Crtieria

- [x] use translation continues to function passing through any string keys as actual strings
